### PR TITLE
Passing 0 arguments to `service` is an error

### DIFF
--- a/service/main.go
+++ b/service/main.go
@@ -361,7 +361,7 @@ func validateArgs() bool {
 	}
 	if len(os.Args) < 2 {
 		// No command to validate
-		return true
+		return false
 	}
 
 	for _, arg := range validArgs {


### PR DESCRIPTION
Check at least one argument is passed on the command line.