### PR TITLE
Add ability to pass GOOS and GOARCH as build parameters

### DIFF
--- a/make.go
+++ b/make.go
@@ -1,4 +1,4 @@
-//// +build ignore
+// +build ignore
 
 // SILVER - Service Wrapper
 //

--- a/make.go
+++ b/make.go
@@ -82,15 +82,6 @@ func main() {
 	}
 }
 
-func find(slice []string, value string) bool {
-	for _, item := range slice {
-		if item == value {
-			return true
-		}
-	}
-	return false
-}
-
 func buildAll() {
 	makeDir(buildOutputDir)
 
@@ -98,12 +89,12 @@ func buildAll() {
 	goarch := os.Getenv("GOARCH")
 
 	fmt.Printf("Building binaries for %s/%s ...\n", goos, goarch)
-	_ = runCmd("go", "build", "-ldflags", "-s -w", "-o", makeOutputPath(buildOutputDir, "updater", goos == "windows"), rootNamespace+"/updater")
-	_ = runCmd("go", "build", "-ldflags", "-s -w", "-o", makeOutputPath(buildOutputDir, "service", goos == "windows"), rootNamespace+"/service")
-	_ = runCmd("go", "build", "-tags", "nohttp", "-ldflags", "-s -w", "-o", makeOutputPath(buildOutputDir, "service-no-http", goos == "windows"), rootNamespace+"/service")
+	_ = runCmd("go", "build", "-ldflags", "-s -w", "-o", makeOutputPath(buildOutputDir, "updater"), rootNamespace+"/updater")
+	_ = runCmd("go", "build", "-ldflags", "-s -w", "-o", makeOutputPath(buildOutputDir, "service"), rootNamespace+"/service")
+	_ = runCmd("go", "build", "-tags", "nohttp", "-ldflags", "-s -w", "-o", makeOutputPath(buildOutputDir, "service-no-http"), rootNamespace+"/service")
 	if goos == "windows" {
-		_ = runCmd("go", "build", "-tags", "nohttp", "-ldflags", "-s -w  -H=windowsgui", "-o", makeOutputPath(buildOutputDir, "service-no-window", goos == "windows"), rootNamespace+"/service")
-		_ = runCmd("go", "build", "-ldflags", "-s -w -H=windowsgui", "-o", makeOutputPath(buildOutputDir, "updater-no-window", goos == "windows"), rootNamespace+"/updater")
+		_ = runCmd("go", "build", "-tags", "nohttp", "-ldflags", "-s -w  -H=windowsgui", "-o", makeOutputPath(buildOutputDir, "service-no-window"), rootNamespace+"/service")
+		_ = runCmd("go", "build", "-ldflags", "-s -w -H=windowsgui", "-o", makeOutputPath(buildOutputDir, "updater-no-window"), rootNamespace+"/updater")
 	}
 
 	fmt.Printf("\nCOMPLETE. You'll find the files in:\n    '%s'\n", buildOutputDir)
@@ -130,8 +121,11 @@ func makeDir(dir string) {
 	}
 }
 
-func makeOutputPath(dir, name string, isWindowsOS bool) string {
-	if isWindowsOS {
+func makeOutputPath(dir, name string) string {
+
+	goos := os.Getenv("GOOS")
+
+	if goos == "windows" {
 		if !strings.HasSuffix(name, ".exe") {
 			name = name + ".exe"
 		}

--- a/make.go
+++ b/make.go
@@ -44,7 +44,7 @@ var (
 )
 
 func usage() {
-	fmt.Println("Usage: go run make.go [flags] [args]")
+	fmt.Println("Usage: go run make.go [flagged args] [non-flagged args]")
 	fmt.Println("-goos=<operating system> target operating system for silver executable. Default is taken from runtime")
 	fmt.Println("-goarch=<architecture> target architecture for silver executable. Default is taken from runtime")
 	fmt.Println("Build action. Can be either 'all'(build all) or 'test'(test all). Default is 'all'")

--- a/make.go
+++ b/make.go
@@ -44,9 +44,10 @@ var (
 )
 
 func usage() {
-	fmt.Println("Usage: go run make.go [command]")
-	fmt.Println("    all")
-	fmt.Println("    test")
+	fmt.Println("Usage: go run make.go [flags] [args]")
+	fmt.Println("-goos=<operating system> target operating system for silver executable. Default is taken from runtime")
+	fmt.Println("-goarch=<architecture> target architecture for silver executable. Default is taken from runtime")
+	fmt.Println("Build action. Can be either 'all'(build all) or 'test'(test all). Default is 'all'")
 	os.Exit(1)
 }
 

--- a/make.go
+++ b/make.go
@@ -68,8 +68,8 @@ func main() {
 	buildOutputDir = filepath.Join(projectRoot, "build", *goos)
 
 	action := "all"
-	if len(flag.Args()) > 0 {
-		action = os.Args[0]
+	if len(flag.Args()) > 1 {
+		action = os.Args[1]
 	}
 
 	switch action {
@@ -95,8 +95,9 @@ func buildAll() {
 	makeDir(buildOutputDir)
 
 	goos := os.Getenv("GOOS")
+	goarch := os.Getenv("GOARCH")
 
-	fmt.Printf("Building binaries for %s...\n", goos)
+	fmt.Printf("Building binaries for %s/%s ...\n", goos, goarch)
 	_ = runCmd("go", "build", "-ldflags", "-s -w", "-o", makeOutputPath(buildOutputDir, "updater", goos == "windows"), rootNamespace+"/updater")
 	_ = runCmd("go", "build", "-ldflags", "-s -w", "-o", makeOutputPath(buildOutputDir, "service", goos == "windows"), rootNamespace+"/service")
 	_ = runCmd("go", "build", "-tags", "nohttp", "-ldflags", "-s -w", "-o", makeOutputPath(buildOutputDir, "service-no-http", goos == "windows"), rootNamespace+"/service")


### PR DESCRIPTION
Enable make.go to accept GOOS and GOARCH as external parameters so that silver binaries for different platforms can be built from a single checkout. This PR doesn't break the existing parameter interface (where it accept a single non flagged optional parameter call 'action')

ex: go run make.go --goos=darwin --goarch=amd64 all
