### PR TITLE
Change go version from 1.13 to 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/papercutsoftware/silver
 
-go 1.13
+go 1.17
 
 require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0


### PR DESCRIPTION
Silver builds on an older go version (1.13).  Windows defender detected a virus ( false positive) in silver binary, so I changed the Go version 1.17 to solve it.
I raised this PR to raise the Go version in Silver.