### PR TITLE
Redirect messages from err-in to err-out and std-in to std-out if logging to console

### DIFF
--- a/lib/logging/logging.go
+++ b/lib/logging/logging.go
@@ -18,7 +18,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"runtime"
@@ -209,11 +209,17 @@ func CloseAllOpenFileLoggers() {
 
 // NewNilLogger is a logger noop/discade implementation
 func NewNilLogger() *log.Logger {
-	return log.New(ioutil.Discard, "", 0)
+	return log.New(io.Discard, "", 0)
 }
 
-// NewConsoleLogger is a basic logger to Stderr
-func NewConsoleLogger() (logger *log.Logger) {
+// NewConsoleErrorLogger is a basic logger to Stderr
+func NewConsoleErrorLogger() (logger *log.Logger) {
 	logger = log.New(os.Stderr, "", log.Ldate|log.Ltime)
+	return logger
+}
+
+// NewConsoleLogger is a basic logger to Stdout
+func NewConsoleLogger() (logger *log.Logger) {
+	logger = log.New(os.Stdout, "", log.Ldate|log.Ltime)
 	return logger
 }

--- a/service/svcutil/svcutil_test.go
+++ b/service/svcutil/svcutil_test.go
@@ -9,6 +9,7 @@ package svcutil_test
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -167,6 +168,55 @@ func Test_ExecuteTask_Logger(t *testing.T) {
 
 	if !strings.Contains(output, "Hello World") {
 		t.Errorf("Expected 'Hello World' in logging output")
+	}
+}
+
+func Test_ExecuteTask_ConsoleLogger(t *testing.T) {
+	// Arrange
+	tmpDir, testExe := makeHelloForeverExe(t)
+	defer os.RemoveAll(tmpDir)
+
+	var logBuf bytes.Buffer
+	var errorlogBuf bytes.Buffer
+
+	taskConf := svcutil.TaskConfig{
+		Path:             testExe,
+		ExecTimeout:      2 * time.Second,
+		GracefulShutDown: 1 * time.Second,
+		Logger:           log.New(&logBuf, "", 0),
+		ErrorLogger:      log.New(&errorlogBuf, "", 0),
+	}
+
+	// Act
+	svcutil.ExecuteTask(nil, taskConf)
+
+	// Assert
+	output := logBuf.String()
+	if len(output) == 0 {
+		t.Fatalf("Expected some logging output")
+	}
+	fmt.Println("output:")
+	fmt.Println(output)
+
+	if !strings.Contains(output, "STDOUT|Hello World") {
+		t.Errorf("Expected 'STDOUT|Hello World' in logging output")
+	}
+	if strings.Contains(output, "STDERR|Sending an error to the world:") {
+		t.Errorf("Did not expect 'STDERR|Sending an error to the world:' in logging output")
+	}
+
+	erroroutput := errorlogBuf.String()
+	if len(erroroutput) == 0 {
+		t.Fatalf("Expected some errorlogging output")
+	}
+	fmt.Println("erroroutput:")
+	fmt.Println(erroroutput)
+
+	if !strings.Contains(erroroutput, "STDERR|Sending an error to the world:") {
+		t.Errorf("Expected 'STDERR|Sending an error to the world:' in logging output")
+	}
+	if strings.Contains(erroroutput, "Hello World") {
+		t.Errorf("Did not expect 'Hello World' in error logging output")
 	}
 }
 

--- a/service/svcutil/svcutil_test.go
+++ b/service/svcutil/svcutil_test.go
@@ -9,7 +9,6 @@ package svcutil_test
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -195,28 +194,24 @@ func Test_ExecuteTask_ConsoleLogger(t *testing.T) {
 	if len(output) == 0 {
 		t.Fatalf("Expected some logging output")
 	}
-	fmt.Println("output:")
-	fmt.Println(output)
 
 	if !strings.Contains(output, "STDOUT|Hello World") {
-		t.Errorf("Expected 'STDOUT|Hello World' in logging output")
+		t.Errorf("Expected 'STDOUT|Hello World' in logging output: %s", output)
 	}
 	if strings.Contains(output, "STDERR|Sending an error to the world:") {
-		t.Errorf("Did not expect 'STDERR|Sending an error to the world:' in logging output")
+		t.Errorf("Did not expect 'STDERR|Sending an error to the world:' in logging output: %s", output)
 	}
 
 	erroroutput := errorlogBuf.String()
 	if len(erroroutput) == 0 {
 		t.Fatalf("Expected some errorlogging output")
 	}
-	fmt.Println("erroroutput:")
-	fmt.Println(erroroutput)
 
 	if !strings.Contains(erroroutput, "STDERR|Sending an error to the world:") {
-		t.Errorf("Expected 'STDERR|Sending an error to the world:' in logging output")
+		t.Errorf("Expected 'STDERR|Sending an error to the world:' in error logging output: %s", erroroutput)
 	}
 	if strings.Contains(erroroutput, "Hello World") {
-		t.Errorf("Did not expect 'Hello World' in error logging output")
+		t.Errorf("Did not expect 'Hello World' in error logging output: %s", erroroutput)
 	}
 }
 

--- a/service/svcutil/testexes/helloforever.go
+++ b/service/svcutil/testexes/helloforever.go
@@ -31,6 +31,8 @@ func main() {
 func sayHelloForever() {
 	for {
 		fmt.Printf("Hello World at %v\n", time.Now())
+		// Print error message to stderr
+		fmt.Fprintf(os.Stderr, "Sending an error to the world: %v\n", "an example error")
 		time.Sleep(1 * time.Second)
 	}
 }


### PR DESCRIPTION
If log is set to "os.stdout", input from services received in stdout will be redirected to stdout and input received on stderr will be sent to stderr
If log is any file, it will just output to that file