### PR TITLE
Pie 823 silver for pup

### DIFF
--- a/updater/main.go
+++ b/updater/main.go
@@ -1,7 +1,7 @@
 // SILVER - Service Wrapper
 // Auto Updater
 //
-// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Copyright (c) 2014-2025 PaperCut Software http://www.papercut.com/
 // Use of this source code is governed by an MIT or GPL Version 2 license.
 // See the project's LICENSE file for more information.
 //
@@ -90,7 +90,11 @@ func main() {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
-	setupHTTPProxy()
+	err := setupHTTPProxy(*httpProxy)
+	if err != nil {
+		fmt.Printf("ERROR: Ignoring error setting up proxy: %v\n", err)
+	}
+
 	ok, err := upgradeIfRequired(checkURL)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)

--- a/updater/proxy.go
+++ b/updater/proxy.go
@@ -1,7 +1,7 @@
 // SILVER - Service Wrapper
 // Auto Updater
 //
-// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Copyright (c) 2014-2025 PaperCut Software http://www.papercut.com/
 // Use of this source code is governed by an MIT or GPL Version 2 license.
 // See the project's LICENSE file for more information.
 //
@@ -16,26 +16,66 @@ import (
 	"strings"
 )
 
-func setupHTTPProxy() {
+// parseProxy parses the proxy String and returns an error if it fails.
+// Copied from net/httpproxy/proxy.go
+func parseProxy(proxy string) (*url.URL, error) {
+	if proxy == "" {
+		return nil, nil
+	}
+
+	proxyURL, err := url.Parse(proxy)
+	if err != nil ||
+		(proxyURL.Scheme != "http" &&
+			proxyURL.Scheme != "https" &&
+			proxyURL.Scheme != "socks5") {
+		// proxy was bogus. Try prepending "http://" to it and
+		// see if that parses correctly. If not, we fall
+		// through and complain about the original one.
+		if proxyURL, err := url.Parse("http://" + proxy); err == nil {
+			return proxyURL, nil
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("invalid proxy address %q: %v", proxy, err)
+	}
+	return proxyURL, nil
+}
+
+// setupHTTPProxy attempts to set the HTTP(S)_PROXY vars using
+// the SILVER_HTTP_PROXY or http-proxy.conf file.
+// Return an error if we attempted and failed to do so or the proxy
+// string was not valid.
+func setupHTTPProxy(httpProxyArg string) error {
 	// Force if set via flag
-	proxy := *httpProxy
+	proxy := httpProxyArg
 
 	if proxy == "" {
 		// Else check Silver Environment
 		proxy = os.Getenv("SILVER_HTTP_PROXY")
 		if proxy == "" {
 			// Else check proxy conf file
+			// If conf file is empty of data then there is no proxy set
 			if dat, err := os.ReadFile("http-proxy.conf"); err == nil {
 				proxy = strings.TrimSpace(string(dat))
+			} else {
+				return err
 			}
 		}
 	}
 
 	if proxy != "" {
+		if _, err := parseProxy(proxy); err != nil {
+			return err
+		}
+		if err := os.Setenv("HTTP_PROXY", proxy); err != nil {
+			return err
+		}
+		if err := os.Setenv("HTTPS_PROXY", proxy); err != nil {
+			return err
+		}
 		fmt.Printf("Using proxy: %s\n", proxy)
-		_ = os.Setenv("HTTP_PROXY", proxy)
-		_ = os.Setenv("HTTPS_PROXY", proxy)
 	}
+	return nil
 }
 
 func turnOffHTTPProxy() {

--- a/updater/proxy.go
+++ b/updater/proxy.go
@@ -35,7 +35,6 @@ func setupHTTPProxy() {
 		fmt.Printf("Using proxy: %s\n", proxy)
 		_ = os.Setenv("HTTP_PROXY", proxy)
 		_ = os.Setenv("HTTPS_PROXY", proxy)
-		return
 	}
 }
 

--- a/updater/proxy.go
+++ b/updater/proxy.go
@@ -9,7 +9,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -18,22 +18,23 @@ import (
 
 func setupHTTPProxy() {
 	// Force if set via flag
-	if len(*httpProxy) > 0 {
-		_ = os.Setenv("HTTP_PROXY", *httpProxy)
-		return
+	proxy := *httpProxy
+
+	if proxy == "" {
+		// Else check Silver Environment
+		proxy = os.Getenv("SILVER_HTTP_PROXY")
+		if proxy == "" {
+			// Else check proxy conf file
+			if dat, err := os.ReadFile("http-proxy.conf"); err == nil {
+				proxy = strings.TrimSpace(string(dat))
+			}
+		}
 	}
-	// Check Silver Environment
-	proxy := os.Getenv("SILVER_HTTP_PROXY")
+
 	if proxy != "" {
+		fmt.Printf("Using proxy: %s\n", proxy)
 		_ = os.Setenv("HTTP_PROXY", proxy)
-		return
-	}
-	// Proxy conf file
-	if dat, err := ioutil.ReadFile("http-proxy.conf"); err == nil {
-		proxy = strings.TrimSpace(string(dat))
-	}
-	if proxy != "" {
-		_ = os.Setenv("HTTP_PROXY", proxy)
+		_ = os.Setenv("HTTPS_PROXY", proxy)
 		return
 	}
 }

--- a/updater/proxy.go
+++ b/updater/proxy.go
@@ -16,31 +16,6 @@ import (
 	"strings"
 )
 
-// parseProxy parses the proxy String and returns an error if it fails.
-// Copied from net/httpproxy/proxy.go
-func parseProxy(proxy string) (*url.URL, error) {
-	if proxy == "" {
-		return nil, nil
-	}
-
-	proxyURL, err := url.Parse(proxy)
-	if err != nil ||
-		(proxyURL.Scheme != "http" &&
-			proxyURL.Scheme != "https" &&
-			proxyURL.Scheme != "socks5") {
-		// proxy was bogus. Try prepending "http://" to it and
-		// see if that parses correctly. If not, we fall
-		// through and complain about the original one.
-		if proxyURL, err := url.Parse("http://" + proxy); err == nil {
-			return proxyURL, nil
-		}
-	}
-	if err != nil {
-		return nil, fmt.Errorf("invalid proxy address %q: %v", proxy, err)
-	}
-	return proxyURL, nil
-}
-
 // setupHTTPProxy attempts to set the HTTP(S)_PROXY vars using
 // the SILVER_HTTP_PROXY or http-proxy.conf file.
 // Return an error if we attempted and failed to do so or the proxy
@@ -64,16 +39,13 @@ func setupHTTPProxy(httpProxyArg string) error {
 	}
 
 	if proxy != "" {
-		if _, err := parseProxy(proxy); err != nil {
-			return err
-		}
 		if err := os.Setenv("HTTP_PROXY", proxy); err != nil {
 			return err
 		}
 		if err := os.Setenv("HTTPS_PROXY", proxy); err != nil {
 			return err
 		}
-		fmt.Printf("Using proxy: %s\n", proxy)
+		fmt.Printf("Using HTTP/HTTPS proxy: %s\n", proxy)
 	}
 	return nil
 }


### PR DESCRIPTION
For Silver's pc-updater code, ensure that HTTPS_PROXY env var is also set.
Since Go 1.16, HTTP_PROXY only affects http traffic and not https traffic anymore.
So we need to set HTTPS_PROXY as well.

Fix up to use os.ReadFile in lieu of ioutil.ReadFile.
Reorganised code so that setting of env vars is done in the one place instead of multiple places as was previously.

Probably, won't normally read the http-proxy.conf file from here as Silver will have already read it and set the SILVER env var.
But don't want to change the functionality here.