### PR TITLE
feat(updater): Add manifest signature verification

### DIFF
--- a/lib/jsonsig/cmd/main.go
+++ b/lib/jsonsig/cmd/main.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/papercutsoftware/silver/lib/jsonsig"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "generate":
+		generateCmd()
+	case "sign":
+		signCmd()
+	case "verify":
+		verifyCmd()
+	default:
+		printUsage()
+		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	fmt.Println("Usage: jsonsign [command] [arguments]")
+	fmt.Println("")
+	fmt.Println("Commands:")
+	fmt.Println("  generate - Generate a new key pair.")
+	fmt.Println("      --public-key=<file>    File to save the public key to. (default: stdout)")
+	fmt.Println("      --private-key=<file>   File to save the private key to. (default: stdout)")
+	fmt.Println("")
+	fmt.Println("  sign - Sign a JSON document.")
+	fmt.Println("      --private-key=<file>   File containing the private key. (required)")
+	fmt.Println("      --input=<file>         File to read the JSON document from. (default: stdin)")
+	fmt.Println("      --output=<file>        File to write the signed JSON document to. (default: stdout)")
+	fmt.Println("")
+	fmt.Println("  verify - Verify a signed JSON document.")
+	fmt.Println("      --public-key=<file>    File containing the public key. (required)")
+	fmt.Println("      --input=<file>         File to read the signed JSON document from. (default: stdin)")
+}
+
+func generateCmd() {
+	generateCmd := flag.NewFlagSet("generate", flag.ExitOnError)
+	publicKeyFile := generateCmd.String("public-key", "", "The file to save the public key to.")
+	privateKeyFile := generateCmd.String("private-key", "", "The file to save the private key to.")
+
+	generateCmd.Parse(os.Args[2:])
+
+	publicKey, privateKey, err := jsonsig.GenerateKeys()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error generating keys: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *publicKeyFile != "" {
+		if err := ioutil.WriteFile(*publicKeyFile, []byte(publicKey), 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing public key to file: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		fmt.Println("Public Key:")
+		fmt.Println(publicKey)
+		fmt.Println("")
+	}
+
+	if *privateKeyFile != "" {
+		if err := ioutil.WriteFile(*privateKeyFile, []byte(privateKey), 0600); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing private key to file: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		fmt.Println("Private Key:")
+		fmt.Println(privateKey)
+	}
+}
+
+func signCmd() {
+	signCmd := flag.NewFlagSet("sign", flag.ExitOnError)
+	privateKeyFile := signCmd.String("private-key", "", "The file containing the private key.")
+	inputFile := signCmd.String("input", "", "The file to read the JSON document from. If not specified, reads from standard input.")
+	outputFile := signCmd.String("output", "", "The file to write the signed JSON document to. If not specified, writes to standard output.")
+
+	signCmd.Parse(os.Args[2:])
+
+	if *privateKeyFile == "" {
+		fmt.Fprintln(os.Stderr, "Error: --private-key is required.")
+		signCmd.Usage()
+		os.Exit(1)
+	}
+
+	privateKeyBytes, err := ioutil.ReadFile(*privateKeyFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading private key: %v\n", err)
+		os.Exit(1)
+	}
+
+	var inputBytes []byte
+	if *inputFile != "" {
+		inputBytes, err = ioutil.ReadFile(*inputFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading input file: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		inputBytes, err = ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading from stdin: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	signedPayload, err := jsonsig.Sign(inputBytes, string(privateKeyBytes))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error signing payload: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *outputFile != "" {
+		if err := ioutil.WriteFile(*outputFile, signedPayload, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing output file: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		fmt.Println(string(signedPayload))
+	}
+}
+
+func verifyCmd() {
+	verifyCmd := flag.NewFlagSet("verify", flag.ExitOnError)
+	publicKeyFile := verifyCmd.String("public-key", "", "The file containing the public key.")
+	inputFile := verifyCmd.String("input", "", "The file to read the signed JSON document from. If not specified, reads from standard input.")
+
+	verifyCmd.Parse(os.Args[2:])
+
+	if *publicKeyFile == "" {
+		fmt.Fprintln(os.Stderr, "Error: --public-key is required.")
+		verifyCmd.Usage()
+		os.Exit(1)
+	}
+
+	publicKeyBytes, err := ioutil.ReadFile(*publicKeyFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading public key: %v\n", err)
+		os.Exit(1)
+	}
+
+	var inputBytes []byte
+	if *inputFile != "" {
+		inputBytes, err = ioutil.ReadFile(*inputFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading input file: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		inputBytes, err = ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading from stdin: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	valid, err := jsonsig.Verify(inputBytes, string(publicKeyBytes))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error verifying signature: %v\n", err)
+		os.Exit(1)
+	}
+
+	if valid {
+		fmt.Println("Verification successful!")
+		os.Exit(0)
+	} else {
+		fmt.Fprintln(os.Stderr, "Verification failed!")
+		os.Exit(1)
+	}
+}

--- a/lib/jsonsig/jsonsig.go
+++ b/lib/jsonsig/jsonsig.go
@@ -1,0 +1,118 @@
+// Package jsonsig provides a simple way to sign and verify JSON payloads using
+// Ed25519 signatures. The signature is attached to the JSON payload (most be
+// a JSON object) in a "signature" field.
+package jsonsig
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/gowebpki/jcs"
+)
+
+// GenerateKeys creates a new Ed25519 key pair.
+// It returns the public key, private key (both base64 encoded), and an error if one occurred.
+func GenerateKeys() (string, string, error) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", "", err
+	}
+
+	privateKeyB64 := base64.StdEncoding.EncodeToString(privateKey)
+	publicKeyB64 := base64.StdEncoding.EncodeToString(publicKey)
+
+	return publicKeyB64, privateKeyB64, nil
+}
+
+// Sign takes a JSON payload and a base64 encoded private key, and returns the
+// signed JSON payload. The signature is added to the JSON payload in a "signature" field.
+func Sign(payload []byte, privateKeyB64 string) ([]byte, error) {
+	// Canonicalize the payload that we will sign.
+	canonicalPayload, err := jcs.Transform(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to canonicalize payload: %w", err)
+	}
+
+	privateKey, err := base64.StdEncoding.DecodeString(privateKeyB64)
+	if err != nil {
+		return nil, err
+	}
+
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.EdDSA, Key: ed25519.PrivateKey(privateKey)}, (&jose.SignerOptions{}).WithHeader("kid", "silver-service-key-v1"))
+	if err != nil {
+		return nil, err
+	}
+
+	jws, err := signer.Sign(canonicalPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the detached compact serialization, which is the signature.
+	compact, err := jws.DetachedCompactSerialize()
+	if err != nil {
+		return nil, err
+	}
+
+	// Now, we need to add the signature to the original payload.
+	// For that we need to unmarshal it into a map.
+	var m map[string]interface{}
+	if err := json.Unmarshal(payload, &m); err != nil {
+		// This should not happen as we are passing the original payload
+		return nil, fmt.Errorf("payload must be a JSON object: %w", err)
+	}
+
+	m["signature"] = compact
+
+	return json.MarshalIndent(m, "", "    ")
+}
+
+// Verify takes a signed JSON payload and a base64 encoded public key, and returns
+// true if the signature is valid.
+func Verify(signedPayload []byte, publicKeyB64 string) (bool, error) {
+	publicKey, err := base64.StdEncoding.DecodeString(publicKeyB64)
+	if err != nil {
+		return false, err
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(signedPayload, &m); err != nil {
+		return false, fmt.Errorf("payload must be a JSON object: %w", err)
+	}
+
+	compact, ok := m["signature"].(string)
+	if !ok {
+		return false, fmt.Errorf("invalid signature format: 'signature' field missing or not a string")
+	}
+
+	delete(m, "signature")
+
+	// To verify, we need to canonicalize the payload as it was before signing.
+	// This means marshaling the map (without signature) back to JSON, and then
+	// canonicalizing that.
+	unsignedPayload, err := json.Marshal(m)
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal unsigned payload: %w", err)
+	}
+
+	canonicalPayload, err := jcs.Transform(unsignedPayload)
+	if err != nil {
+		return false, fmt.Errorf("failed to canonicalize payload for verification: %w", err)
+	}
+
+	object, err := jose.ParseDetached(compact, canonicalPayload, []jose.SignatureAlgorithm{jose.EdDSA})
+	if err != nil {
+		return false, fmt.Errorf("failed to parse detached signature: %w", err)
+	}
+
+	_, err = object.Verify(ed25519.PublicKey(publicKey))
+	if err != nil {
+		return false, fmt.Errorf("signature verification failed: %w", err)
+	}
+
+	return true, nil
+}

--- a/lib/jsonsig/jsonsig_test.go
+++ b/lib/jsonsig/jsonsig_test.go
@@ -1,0 +1,94 @@
+package jsonsig
+
+import (
+	"testing"
+)
+
+func TestSignAndVerify(t *testing.T) {
+	// Generate a new key pair for testing.
+	publicKey, privateKey, err := GenerateKeys()
+	if err != nil {
+		t.Fatalf("Failed to generate keys: %v", err)
+	}
+
+	// Create a sample JSON payload.
+	payload := []byte(`{"foo": "bar"}`)
+
+	// Sign the payload.
+	signedPayload, err := Sign(payload, privateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign payload: %v", err)
+	}
+
+	// Verify the signature.
+	valid, err := Verify(signedPayload, publicKey)
+	if err != nil {
+		t.Fatalf("Failed to verify signature: %v", err)
+	}
+
+	if !valid {
+		t.Error("Signature should be valid, but it was not.")
+	}
+}
+
+func TestVerificationFailureWithDifferentPublicKey(t *testing.T) {
+	// Generate two different key pairs.
+	_, privateKey, err := GenerateKeys()
+	if err != nil {
+		t.Fatalf("Failed to generate keys: %v", err)
+	}
+
+	publicKey2, _, err := GenerateKeys()
+	if err != nil {
+		t.Fatalf("Failed to generate keys: %v", err)
+	}
+
+	// Create a sample JSON payload.
+	payload := []byte(`{"foo": "bar"}`)
+
+	// Sign the payload with the first private key.
+	signedPayload, err := Sign(payload, privateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign payload: %v", err)
+	}
+
+	// Try to verify the signature with the second public key.
+	valid, err := Verify(signedPayload, publicKey2)
+	if err == nil {
+		t.Error("Verification should have failed, but it did not.")
+	}
+
+	if valid {
+		t.Error("Signature should be invalid, but it was considered valid.")
+	}
+}
+
+func TestVerificationFailureWithTamperedPayload(t *testing.T) {
+	// Generate a new key pair for testing.
+	publicKey, privateKey, err := GenerateKeys()
+	if err != nil {
+		t.Fatalf("Failed to generate keys: %v", err)
+	}
+
+	// Create a sample JSON payload.
+	payload := []byte(`{"foo": "bar"}`)
+
+	// Sign the payload.
+	signedPayload, err := Sign(payload, privateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign payload: %v", err)
+	}
+
+	// Tamper with the signed payload.
+	signedPayload[0] = 'A'
+
+	// Try to verify the signature of the tampered payload.
+	valid, err := Verify(signedPayload, publicKey)
+	if err == nil {
+		t.Error("Verification should have failed, but it did not.")
+	}
+
+	if valid {
+		t.Error("Signature should be invalid, but it was considered valid.")
+	}
+}


### PR DESCRIPTION
First cut of cryptographic verification of the update manifest, enhancing security in selected situations (e.g. insecure transport or server compromise)

The update manifest (JSON) can now be signed using an Ed25519 private key. The `updater` client can then verify this signature using the corresponding public key.

This change introduces a new optional command-line flag:

  --public-key="(key)"

If the `--public-key` flag is provided during execution, the updater will:
1.  Fetch the update manifest from the server.
2.  Verify the manifest's signature using the provided public key.
3.  Abort the update process if the signature is invalid.

If the flag is omitted, the updater skips verification and maintains its original behavior.