### PR TITLE
Feature/Add microseconds timestamp flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The configuration file is the heart of Silver. Here is a comprehensive example w
         "LogFileMaxBackupFiles": 5,
         // Include date/time on each log line (default: true)
         "LogFileAddTimestamps": true,
+        // Include microseconds in timestamps when enabled (default: false)
+        "LogFileTimestampMicroseconds": false,
 
         // File to store the current main service PID.
         "PidFile": "${ServiceRoot}/${ServiceName}.pid",

--- a/README.md
+++ b/README.md
@@ -82,8 +82,7 @@ The configuration file is the heart of Silver. Here is a comprehensive example w
         "LogFile": "${ServiceRoot}/${ServiceName}.log",
         "LogFileMaxSizeMb": 50,
         "LogFileMaxBackupFiles": 5,
-        // Include date/time on each log line (default: true)
-        "LogFileAddTimestamps": true,
+
         // Include microseconds in timestamps when enabled (default: false)
         "LogFileTimestampMicroseconds": false,
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The configuration file is the heart of Silver. Here is a comprehensive example w
         "LogFile": "${ServiceRoot}/${ServiceName}.log",
         "LogFileMaxSizeMb": 50,
         "LogFileMaxBackupFiles": 5,
+        // Include date/time on each log line (default: true)
+        "LogFileAddTimestamps": true,
 
         // File to store the current main service PID.
         "PidFile": "${ServiceRoot}/${ServiceName}.pid",
@@ -434,4 +436,3 @@ This project is licensed under the MIT Licence. See the `LICENSE` file for detai
 ## **About This Project**
 
 Silver is an open-source project actively maintained and supported by PaperCut Software. It is battle-tested technology, used in production to manage server and desktop components for millions of laptops and servers running [PaperCut's print management software](https://www.papercut.com/) for nearly a decade.  Silver is a better tool thanks to the collective effort of its community. A big thank you to everyone who has contributed their time, ideas, and code to the project.
-

--- a/conf/examples/silver-kitchen-sink.conf
+++ b/conf/examples/silver-kitchen-sink.conf
@@ -10,6 +10,7 @@
         "LogFileMaxSizeMb": 200,
         "LogFileMaxBackupFiles": 5,
         "LogFileAddTimestamps": false,
+        "LogFileTimestampMicroseconds": false,
         "PidFile": "${ServiceName}.pid"
     },
     "EnvironmentVars": {

--- a/conf/examples/silver-kitchen-sink.conf
+++ b/conf/examples/silver-kitchen-sink.conf
@@ -9,7 +9,6 @@
         "LogFile": "${ServiceName}.log",
         "LogFileMaxSizeMb": 200,
         "LogFileMaxBackupFiles": 5,
-        "LogFileAddTimestamps": false,
         "LogFileTimestampMicroseconds": false,
         "PidFile": "${ServiceName}.pid"
     },

--- a/conf/examples/silver-kitchen-sink.conf
+++ b/conf/examples/silver-kitchen-sink.conf
@@ -9,6 +9,7 @@
         "LogFile": "${ServiceName}.log",
         "LogFileMaxSizeMb": 200,
         "LogFileMaxBackupFiles": 5,
+        "LogFileAddTimestamps": false,
         "PidFile": "${ServiceName}.pid"
     },
     "EnvironmentVars": {

--- a/lib/logging/logging_test.go
+++ b/lib/logging/logging_test.go
@@ -1,11 +1,12 @@
 package logging
 
 import (
-	"fmt"
-	"os"
-	"strings"
-	"testing"
-	"time"
+    "fmt"
+    "os"
+    "regexp"
+    "strings"
+    "testing"
+    "time"
 )
 
 func TestStandardLogging(t *testing.T) {
@@ -28,6 +29,58 @@ func TestStandardLogging(t *testing.T) {
 	if !strings.Contains(string(output), msg) {
 		t.Errorf("Expected '%s', got '%s'", msg, output)
 	}
+}
+
+func TestLogging_TimestampsOnByDefault(t *testing.T) {
+    lname := fmt.Sprintf("%s/test-timestamps-on-%d.log", os.TempDir(), time.Now().UnixNano())
+
+    logger := NewFileLogger(lname, "")
+    defer func() {
+        os.Remove(lname)
+    }()
+
+    msg := "TimestampsOnByDefault"
+    logger.Printf(msg)
+    CloseAllOpenFileLoggers()
+
+    data, err := os.ReadFile(lname)
+    if err != nil {
+        t.Fatalf("Unable to read file: %v", err)
+    }
+    line := strings.SplitN(string(data), "\n", 2)[0]
+    // Default flags include date and time. Format: YYYY/MM/DD HH:MM:SS ...
+    re := regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} `)
+    if !re.MatchString(line) {
+        t.Fatalf("expected timestamp prefix, got: %q", line)
+    }
+    if !strings.Contains(line, msg) {
+        t.Fatalf("expected message %q in line %q", msg, line)
+    }
+}
+
+func TestLogging_TimestampsDisabledWithZeroFlags(t *testing.T) {
+    lname := fmt.Sprintf("%s/test-timestamps-off-%d.log", os.TempDir(), time.Now().UnixNano())
+
+    logger := NewFileLogger(lname, "")
+    // Simulate disabling timestamps (as service/main.go does)
+    logger.SetFlags(0)
+    defer func() {
+        os.Remove(lname)
+    }()
+
+    msg := "TimestampsOff"
+    logger.Printf(msg)
+    CloseAllOpenFileLoggers()
+
+    data, err := os.ReadFile(lname)
+    if err != nil {
+        t.Fatalf("Unable to read file: %v", err)
+    }
+    line := strings.SplitN(string(data), "\n", 2)[0]
+    // With flags=0 we expect no date/time prefix; line should start with msg
+    if !strings.HasPrefix(line, msg) {
+        t.Fatalf("expected line to start with message %q, got %q", msg, line)
+    }
 }
 
 func TestRollingLog(t *testing.T) {

--- a/lib/logging/logging_test.go
+++ b/lib/logging/logging_test.go
@@ -1,13 +1,13 @@
 package logging
 
 import (
-    "fmt"
-    "log"
-    "os"
-    "regexp"
-    "strings"
-    "testing"
-    "time"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
 )
 
 func TestStandardLogging(t *testing.T) {
@@ -27,62 +27,9 @@ func TestStandardLogging(t *testing.T) {
 		t.Errorf("Unable to read file: %v", err)
 	}
 
-	log := string(output)
-	if !strings.Contains(log, msg) {
-		t.Errorf("Expected '%s', got '%s'", msg, log)
+	if !strings.Contains(string(output), msg) {
+		t.Errorf("Expected '%s', got '%s'", msg, output)
 	}
-}
-
-func TestLogging_TimestampsOnByDefault(t *testing.T) {
-    lname := fmt.Sprintf("%s/test-timestamps-on-%d.log", os.TempDir(), time.Now().UnixNano())
-
-    logger := NewFileLogger(lname, "")
-    defer func() {
-        os.Remove(lname)
-    }()
-
-    msg := "TimestampsOnByDefault"
-    logger.Printf(msg)
-    CloseAllOpenFileLoggers()
-
-    data, err := os.ReadFile(lname)
-    if err != nil {
-        t.Fatalf("Unable to read file: %v", err)
-    }
-    line := strings.SplitN(string(data), "\n", 2)[0]
-    // Default flags include date and time. Format: YYYY/MM/DD HH:MM:SS ...
-    re := regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} `)
-    if !re.MatchString(line) {
-        t.Fatalf("expected timestamp prefix, got: %q", line)
-    }
-    if !strings.Contains(line, msg) {
-        t.Fatalf("expected message %q in line %q", msg, line)
-    }
-}
-
-func TestLogging_TimestampsDisabledWithZeroFlags(t *testing.T) {
-    lname := fmt.Sprintf("%s/test-timestamps-off-%d.log", os.TempDir(), time.Now().UnixNano())
-
-    logger := NewFileLogger(lname, "")
-    // Simulate disabling timestamps (as service/main.go does)
-    logger.SetFlags(0)
-    defer func() {
-        os.Remove(lname)
-    }()
-
-    msg := "TimestampsOff"
-    logger.Printf(msg)
-    CloseAllOpenFileLoggers()
-
-    data, err := os.ReadFile(lname)
-    if err != nil {
-        t.Fatalf("Unable to read file: %v", err)
-    }
-    line := strings.SplitN(string(data), "\n", 2)[0]
-    // With flags=0 we expect no date/time prefix; line should start with msg
-    if !strings.HasPrefix(line, msg) {
-        t.Fatalf("expected line to start with message %q, got %q", msg, line)
-    }
 }
 
 func TestRollingLog(t *testing.T) {
@@ -157,30 +104,30 @@ func TestRollingLogFlush_IsFlushed(t *testing.T) {
 }
 
 func TestLogging_TimestampsWithMicroseconds(t *testing.T) {
-    lname := fmt.Sprintf("%s/test-timestamps-micro-%d.log", os.TempDir(), time.Now().UnixNano())
+	lname := fmt.Sprintf("%s/test-timestamps-micro-%d.log", os.TempDir(), time.Now().UnixNano())
 
-    logger := NewFileLogger(lname, "")
-    // Enable microseconds in timestamp
-    logger.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
-    defer func() {
-        os.Remove(lname)
-    }()
+	logger := NewFileLogger(lname, "")
+	// Enable microseconds in timestamp
+	logger.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
+	defer func() {
+		os.Remove(lname)
+	}()
 
-    msg := "TimestampsWithMicroseconds"
-    logger.Printf(msg)
-    CloseAllOpenFileLoggers()
+	msg := "TimestampsWithMicroseconds"
+	logger.Printf(msg)
+	CloseAllOpenFileLoggers()
 
-    data, err := os.ReadFile(lname)
-    if err != nil {
-        t.Fatalf("Unable to read file: %v", err)
-    }
-    line := strings.SplitN(string(data), "\n", 2)[0]
-    // Expect format: YYYY/MM/DD HH:MM:SS.mmmuuu <msg>
-    re := regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}\.\d{6} `)
-    if !re.MatchString(line) {
-        t.Fatalf("expected microsecond timestamp prefix, got: %q", line)
-    }
-    if !strings.Contains(line, msg) {
-        t.Fatalf("expected message %q in line %q", msg, line)
-    }
+	data, err := os.ReadFile(lname)
+	if err != nil {
+		t.Fatalf("Unable to read file: %v", err)
+	}
+	line := strings.SplitN(string(data), "\n", 2)[0]
+	// Expect format: YYYY/MM/DD HH:MM:SS.mmmuuu <msg>
+	re := regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}\.\d{6} `)
+	if !re.MatchString(line) {
+		t.Fatalf("expected microsecond timestamp prefix, got: %q", line)
+	}
+	if !strings.Contains(line, msg) {
+		t.Fatalf("expected message %q in line %q", msg, line)
+	}
 }

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -48,9 +48,12 @@ type ServiceConfig struct {
 	PidFile               string
 	UserLevel             bool
 	UserName              string
-	// LogFileAddTimestamps controls whether log entries include date/time prefixes.
-	// Defaults to true for backward compatibility.
-	LogFileAddTimestamps *bool
+    // LogFileAddTimestamps controls whether log entries include date/time prefixes.
+    // Defaults to true for backward compatibility.
+    LogFileAddTimestamps *bool
+    // LogFileTimestampMicroseconds controls whether timestamps include microseconds
+    // when LogFileAddTimestamps is enabled. Defaults to false.
+    LogFileTimestampMicroseconds *bool
 }
 
 type command struct {
@@ -214,11 +217,17 @@ func (conf *Config) applyDefaults() {
 		conf.EnvironmentVars = make(map[string]string)
 	}
 
-	// Default to including timestamps in logs if not specified
-	if conf.ServiceConfig.LogFileAddTimestamps == nil {
-		t := true
-		conf.ServiceConfig.LogFileAddTimestamps = &t
-	}
+    // Default to including timestamps in logs if not specified
+    if conf.ServiceConfig.LogFileAddTimestamps == nil {
+        t := true
+        conf.ServiceConfig.LogFileAddTimestamps = &t
+    }
+
+    // Default to not including microseconds in timestamps if not specified
+    if conf.ServiceConfig.LogFileTimestampMicroseconds == nil {
+        m := false
+        conf.ServiceConfig.LogFileTimestampMicroseconds = &m
+    }
 
 	// Default graceful is 5 seconds
 	for i := range conf.Services {

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -40,20 +40,15 @@ type ServiceDescription struct {
 }
 
 type ServiceConfig struct {
-	StopFile              string
-	ReloadFile            string
-	LogFile               string
-	LogFileMaxSizeMb      int64
-	LogFileMaxBackupFiles int
-	PidFile               string
-	UserLevel             bool
-	UserName              string
-    // LogFileAddTimestamps controls whether log entries include date/time prefixes.
-    // Defaults to true for backward compatibility.
-    LogFileAddTimestamps *bool
-    // LogFileTimestampMicroseconds controls whether timestamps include microseconds
-    // when LogFileAddTimestamps is enabled. Defaults to false.
-    LogFileTimestampMicroseconds *bool
+	StopFile                     string
+	ReloadFile                   string
+	LogFile                      string
+	LogFileMaxSizeMb             int64
+	LogFileMaxBackupFiles        int
+	PidFile                      string
+	UserLevel                    bool
+	UserName                     string
+	LogFileTimestampMicroseconds *bool
 }
 
 type command struct {
@@ -217,17 +212,11 @@ func (conf *Config) applyDefaults() {
 		conf.EnvironmentVars = make(map[string]string)
 	}
 
-    // Default to including timestamps in logs if not specified
-    if conf.ServiceConfig.LogFileAddTimestamps == nil {
-        t := true
-        conf.ServiceConfig.LogFileAddTimestamps = &t
-    }
-
-    // Default to not including microseconds in timestamps if not specified
-    if conf.ServiceConfig.LogFileTimestampMicroseconds == nil {
-        m := false
-        conf.ServiceConfig.LogFileTimestampMicroseconds = &m
-    }
+	// Default to not including microseconds in timestamps if not specified
+	if conf.ServiceConfig.LogFileTimestampMicroseconds == nil {
+		m := false
+		conf.ServiceConfig.LogFileTimestampMicroseconds = &m
+	}
 
 	// Default graceful is 5 seconds
 	for i := range conf.Services {

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -48,6 +48,9 @@ type ServiceConfig struct {
 	PidFile               string
 	UserLevel             bool
 	UserName              string
+	// LogFileAddTimestamps controls whether log entries include date/time prefixes.
+	// Defaults to true for backward compatibility.
+	LogFileAddTimestamps *bool
 }
 
 type command struct {
@@ -209,6 +212,12 @@ func (conf *Config) applyDefaults() {
 
 	if conf.EnvironmentVars == nil {
 		conf.EnvironmentVars = make(map[string]string)
+	}
+
+	// Default to including timestamps in logs if not specified
+	if conf.ServiceConfig.LogFileAddTimestamps == nil {
+		t := true
+		conf.ServiceConfig.LogFileAddTimestamps = &t
 	}
 
 	// Default graceful is 5 seconds

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -48,7 +48,7 @@ type ServiceConfig struct {
 	PidFile                      string
 	UserLevel                    bool
 	UserName                     string
-	LogFileTimestampMicroseconds *bool
+	LogFileTimestampMicroseconds bool
 }
 
 type command struct {
@@ -210,12 +210,6 @@ func (conf *Config) applyDefaults() {
 
 	if conf.EnvironmentVars == nil {
 		conf.EnvironmentVars = make(map[string]string)
-	}
-
-	// Default to not including microseconds in timestamps if not specified
-	if conf.ServiceConfig.LogFileTimestampMicroseconds == nil {
-		m := false
-		conf.ServiceConfig.LogFileTimestampMicroseconds = &m
 	}
 
 	// Default graceful is 5 seconds

--- a/service/main.go
+++ b/service/main.go
@@ -123,6 +123,20 @@ func osServiceControl(ctx *context) int {
 		if ctx.errorLogger != nil {
 			ctx.errorLogger.SetFlags(0)
 		}
+	} else {
+		// Configure timestamp precision
+		useMicro := false
+		if ctx.conf.ServiceConfig.LogFileTimestampMicroseconds != nil {
+			useMicro = *ctx.conf.ServiceConfig.LogFileTimestampMicroseconds
+		}
+		flags := log.Ldate | log.Ltime
+		if useMicro {
+			flags |= log.Lmicroseconds
+		}
+		ctx.logger.SetFlags(flags)
+		if ctx.errorLogger != nil {
+			ctx.errorLogger.SetFlags(flags)
+		}
 	}
 
 	// Setup service

--- a/service/main.go
+++ b/service/main.go
@@ -155,11 +155,7 @@ func osServiceControl(ctx *context) int {
 
 // If "ServiceConfig": {"LogFileTimestampMicroseconds": true} is set in the config, then add microseconds to the log timestamp. By default, log timestamps are to the second only.
 func applyMicrosecondsLoggingConfiguration(ctx *context) {
-	useMicroseconds := false
-	if ctx.conf.ServiceConfig.LogFileTimestampMicroseconds != nil {
-		useMicroseconds = *ctx.conf.ServiceConfig.LogFileTimestampMicroseconds
-	}
-	if useMicroseconds {
+	if ctx.conf.ServiceConfig.LogFileTimestampMicroseconds {
 		flags := log.Ldate | log.Ltime | log.Lmicroseconds
 		ctx.logger.SetFlags(flags)
 		ctx.errorLogger.SetFlags(flags)

--- a/service/main.go
+++ b/service/main.go
@@ -113,30 +113,15 @@ func osServiceControl(ctx *context) int {
 		ctx.errorLogger = ctx.logger // use the same output for both stdout and errors
 	}
 
-	// Respect LogFileAddTimestamps flag (default true). When false, remove date/time prefixes.
-	LogFileAddTimestamps := true
-	if ctx.conf.ServiceConfig.LogFileAddTimestamps != nil {
-		LogFileAddTimestamps = *ctx.conf.ServiceConfig.LogFileAddTimestamps
+	// Configure timestamp precision. Add microseconds if requested.
+	useMicro := false
+	if ctx.conf.ServiceConfig.LogFileTimestampMicroseconds != nil {
+		useMicro = *ctx.conf.ServiceConfig.LogFileTimestampMicroseconds
 	}
-	if !LogFileAddTimestamps {
-		ctx.logger.SetFlags(0)
-		if ctx.errorLogger != nil {
-			ctx.errorLogger.SetFlags(0)
-		}
-	} else {
-		// Configure timestamp precision
-		useMicro := false
-		if ctx.conf.ServiceConfig.LogFileTimestampMicroseconds != nil {
-			useMicro = *ctx.conf.ServiceConfig.LogFileTimestampMicroseconds
-		}
-		flags := log.Ldate | log.Ltime
-		if useMicro {
-			flags |= log.Lmicroseconds
-		}
+	if useMicro {
+		flags := log.Ldate | log.Ltime | log.Lmicroseconds
 		ctx.logger.SetFlags(flags)
-		if ctx.errorLogger != nil {
-			ctx.errorLogger.SetFlags(flags)
-		}
+		ctx.errorLogger.SetFlags(flags)
 	}
 
 	// Setup service

--- a/service/main.go
+++ b/service/main.go
@@ -113,6 +113,18 @@ func osServiceControl(ctx *context) int {
 		ctx.errorLogger = ctx.logger // use the same output for both stdout and errors
 	}
 
+	// Respect LogFileAddTimestamps flag (default true). When false, remove date/time prefixes.
+	LogFileAddTimestamps := true
+	if ctx.conf.ServiceConfig.LogFileAddTimestamps != nil {
+		LogFileAddTimestamps = *ctx.conf.ServiceConfig.LogFileAddTimestamps
+	}
+	if !LogFileAddTimestamps {
+		ctx.logger.SetFlags(0)
+		if ctx.errorLogger != nil {
+			ctx.errorLogger.SetFlags(0)
+		}
+	}
+
 	// Setup service
 	svcConfig := &service.Config{
 		Name:        serviceName,

--- a/service/main_logging_test.go
+++ b/service/main_logging_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/papercutsoftware/silver/lib/logging"
+	"github.com/papercutsoftware/silver/service/config"
+)
+
+func TestLogging_SampleConfigWithoutMicroseconds(t *testing.T) {
+	cfg := loadTestConfig(t, "logging-no-microseconds.conf")
+	logPath := filepath.Join(t.TempDir(), "no-micro.log")
+	cfg.ServiceConfig.LogFile = logPath
+
+	logger := logging.NewFileLogger(cfg.ServiceConfig.LogFile, cfg.ServiceConfig.UserName)
+	t.Cleanup(logging.CloseAllOpenFileLoggers)
+
+	ctx := &context{
+		conf:        cfg,
+		logger:      logger,
+		errorLogger: logger,
+	}
+	// this is usually done in main(), but we need to do it here for the test
+	applyMicrosecondsLoggingConfiguration(ctx)
+
+	msg := "LoggingWithoutMicroseconds"
+	logger.Printf(msg)
+	logging.CloseAllOpenFileLoggers()
+
+	data, err := os.ReadFile(cfg.ServiceConfig.LogFile)
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+	line := strings.SplitN(string(data), "\n", 2)[0]
+
+	reDate := regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} `)
+	if !reDate.MatchString(line) {
+		t.Fatalf("expected timestamp without microseconds, got %q", line)
+	}
+
+	reMicro := regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}\.\d{6} `)
+	if reMicro.MatchString(line) {
+		t.Fatalf("did not expect microsecond precision, got %q", line)
+	}
+
+	if !strings.Contains(line, msg) {
+		t.Fatalf("expected log line to contain %q, got %q", msg, line)
+	}
+}
+
+func TestLogging_SampleConfigWithMicroseconds(t *testing.T) {
+	cfg := loadTestConfig(t, "logging-with-microseconds.conf")
+	logPath := filepath.Join(t.TempDir(), "with-micro.log")
+	cfg.ServiceConfig.LogFile = logPath
+
+	logger := logging.NewFileLogger(cfg.ServiceConfig.LogFile, cfg.ServiceConfig.UserName)
+	t.Cleanup(logging.CloseAllOpenFileLoggers)
+
+	ctx := &context{
+		conf:        cfg,
+		logger:      logger,
+		errorLogger: logger,
+	}
+	// this is usually done in main(), but we need to do it here for the test
+	applyMicrosecondsLoggingConfiguration(ctx)
+
+	msg := "LoggingWithMicroseconds"
+	logger.Printf(msg)
+	logging.CloseAllOpenFileLoggers()
+
+	data, err := os.ReadFile(cfg.ServiceConfig.LogFile)
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+	line := strings.SplitN(string(data), "\n", 2)[0]
+
+	re := regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}\.\d{6} `)
+	if !re.MatchString(line) {
+		t.Fatalf("expected microsecond precision, got %q", line)
+	}
+
+	if !strings.Contains(line, msg) {
+		t.Fatalf("expected log line to contain %q, got %q", msg, line)
+	}
+}
+
+func loadTestConfig(t *testing.T, filename string) *config.Config {
+	t.Helper()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("unable to resolve current file path")
+	}
+	baseDir := filepath.Dir(currentFile)
+	path := filepath.Join(baseDir, "testdata", filename)
+
+	vars := config.ReplacementVars{
+		ServiceName: "silver-test",
+		ServiceRoot: t.TempDir(),
+	}
+
+	cfg, err := config.LoadConfig(path, vars)
+	if err != nil {
+		t.Fatalf("loading config %s: %v", path, err)
+	}
+
+	return cfg
+}

--- a/service/main_logging_test.go
+++ b/service/main_logging_test.go
@@ -28,8 +28,9 @@ func TestLogging_SampleConfigWithoutMicroseconds(t *testing.T) {
 	// this is usually done in main(), but we need to do it here for the test
 	applyMicrosecondsLoggingConfiguration(ctx)
 
-	msg := "LoggingWithoutMicroseconds"
-	logger.Printf(msg)
+	testmessage := "LoggingWithoutMicroseconds"
+	msg := "%s %t"
+	logger.Printf(msg, testmessage, ctx.conf.ServiceConfig.LogFileTimestampMicroseconds)
 	logging.CloseAllOpenFileLoggers()
 
 	data, err := os.ReadFile(cfg.ServiceConfig.LogFile)
@@ -48,8 +49,8 @@ func TestLogging_SampleConfigWithoutMicroseconds(t *testing.T) {
 		t.Fatalf("did not expect microsecond precision, got %q", line)
 	}
 
-	if !strings.Contains(line, msg) {
-		t.Fatalf("expected log line to contain %q, got %q", msg, line)
+	if !strings.Contains(line, testmessage) {
+		t.Fatalf("expected log line to contain %q, got %q", testmessage, line)
 	}
 }
 
@@ -69,8 +70,9 @@ func TestLogging_SampleConfigWithMicroseconds(t *testing.T) {
 	// this is usually done in main(), but we need to do it here for the test
 	applyMicrosecondsLoggingConfiguration(ctx)
 
-	msg := "LoggingWithMicroseconds"
-	logger.Printf(msg)
+	testmessage := "LoggingWithMicroseconds"
+	msg := "%s %t"
+	logger.Printf(msg, testmessage, ctx.conf.ServiceConfig.LogFileTimestampMicroseconds)
 	logging.CloseAllOpenFileLoggers()
 
 	data, err := os.ReadFile(cfg.ServiceConfig.LogFile)
@@ -84,8 +86,8 @@ func TestLogging_SampleConfigWithMicroseconds(t *testing.T) {
 		t.Fatalf("expected microsecond precision, got %q", line)
 	}
 
-	if !strings.Contains(line, msg) {
-		t.Fatalf("expected log line to contain %q, got %q", msg, line)
+	if !strings.Contains(line, testmessage) {
+		t.Fatalf("expected log line to contain %q, got %q", testmessage, line)
 	}
 }
 

--- a/service/testdata/logging-no-microseconds.conf
+++ b/service/testdata/logging-no-microseconds.conf
@@ -4,8 +4,7 @@
     "Description": "Test config for logging without microsecond precision"
   },
   "ServiceConfig": {
-    "LogFile": "${ServiceName}.log",
-    "LogFileTimestampMicroseconds": false
+    "LogFile": "${ServiceName}.log"
   },
   "Services": [
     {

--- a/service/testdata/logging-no-microseconds.conf
+++ b/service/testdata/logging-no-microseconds.conf
@@ -1,0 +1,15 @@
+{
+  "ServiceDescription": {
+    "DisplayName": "Test Service Without Microseconds",
+    "Description": "Test config for logging without microsecond precision"
+  },
+  "ServiceConfig": {
+    "LogFile": "${ServiceName}.log",
+    "LogFileTimestampMicroseconds": false
+  },
+  "Services": [
+    {
+      "Path": "test/path"
+    }
+  ]
+}

--- a/service/testdata/logging-with-microseconds.conf
+++ b/service/testdata/logging-with-microseconds.conf
@@ -1,0 +1,15 @@
+{
+  "ServiceDescription": {
+    "DisplayName": "Test Service With Microseconds",
+    "Description": "Test config for logging with microsecond precision"
+  },
+  "ServiceConfig": {
+    "LogFile": "${ServiceName}.log",
+    "LogFileTimestampMicroseconds": true
+  },
+  "Services": [
+    {
+      "Path": "test/path"
+    }
+  ]
+}


### PR DESCRIPTION
Added a new flag to ServiceConfig to enable microseconds in the logfile

```
    "ServiceConfig": {
        "LogFileTimestampMicroseconds": true
    },
```

By default it will be false, but if enabled you will have microsecond precision in the logfile

```
2025/09/16 21:27:07.390650 pc-listener: STDOUT|something happened
2025/09/16 21:27:07.644849 pc-listener: STDOUT|something else happened
```