### PR TITLE
Feature/custom logformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ The configuration file is the heart of Silver. Here is a comprehensive example w
         "LogFileMaxSizeMb": 50,
         "LogFileMaxBackupFiles": 5,
 
+        // Custom format for log timestamps (e.g., "2006-01-02 15:04:05.000").
+        // If set, this overrides the default timestamp format.
+        "LogFileTimestampFormat": "2006-01-02 15:04:05.000000",
+
         // File to store the current main service PID.
         "PidFile": "${ServiceRoot}/${ServiceName}.pid",
 
@@ -434,4 +438,3 @@ This project is licensed under the MIT Licence. See the `LICENSE` file for detai
 ## **About This Project**
 
 Silver is an open-source project actively maintained and supported by PaperCut Software. It is battle-tested technology, used in production to manage server and desktop components for millions of laptops and servers running [PaperCut's print management software](https://www.papercut.com/) for nearly a decade.  Silver is a better tool thanks to the collective effort of its community. A big thank you to everyone who has contributed their time, ideas, and code to the project.
-

--- a/conf/examples/silver-kitchen-sink.conf
+++ b/conf/examples/silver-kitchen-sink.conf
@@ -9,6 +9,7 @@
         "LogFile": "${ServiceName}.log",
         "LogFileMaxSizeMb": 200,
         "LogFileMaxBackupFiles": 5,
+        "LogFileTimestampFormat": "2006-01-02 15:04:05",
         "PidFile": "${ServiceName}.pid"
     },
     "EnvironmentVars": {

--- a/conf/examples/silver-log-stdout.conf
+++ b/conf/examples/silver-log-stdout.conf
@@ -4,7 +4,8 @@
         "Description": "Only does one thing, but does it well!"
     },
     "ServiceConfig": {
-        "LogFile": "os.stdout"
+        "LogFile": "os.stdout",
+        "LogFileTimestampFormat": "2006-01-02 15:04:05"
     },
     "Services": [
         {

--- a/lib/logging/logging.go
+++ b/lib/logging/logging.go
@@ -64,6 +64,16 @@ func init() {
 	changeOwnerOfFileFunc = changeOwnerOfFile
 }
 
+type logWriter struct {
+	io.Writer
+	timeformat string
+}
+
+// custom Write to add timestamps with custom format
+func (writer logWriter) Write(bytes []byte) (int, error) {
+	return fmt.Fprintf(writer.Writer, "%s %s", time.Now().Format(writer.timeformat), string(bytes))
+}
+
 func (f *flusher) run(rf *rollingFile) {
 	tick := time.Tick(f.interval)
 	for {
@@ -176,12 +186,12 @@ func openLogFile(name string, owner string) (f *os.File, err error) {
 }
 
 // NewFileLogger implements a rolling logger with default maximum size (50Mb)
-func NewFileLogger(file string, owner string) (logger *log.Logger) {
-	return NewFileLoggerWithMaxSize(file, owner, defaultMaxSize, defaultMaxBackupFiles)
+func NewFileLogger(file string, owner string, timeformat string) (logger *log.Logger) {
+	return NewFileLoggerWithMaxSize(file, owner, defaultMaxSize, defaultMaxBackupFiles, timeformat)
 }
 
 // NewFileLoggerWithMaxSize implements a rolling logger with a set size
-func NewFileLoggerWithMaxSize(file string, owner string, maxSize int64, maxBackupFiles int) (logger *log.Logger) {
+func NewFileLoggerWithMaxSize(file string, owner string, maxSize int64, maxBackupFiles int, timeformat string) (logger *log.Logger) {
 	rf, err := newRollingFile(file, owner, maxSize, maxBackupFiles)
 	// This trick ensures that the flusher goroutine does not keep
 	// the returned wrapper object from being garbage collected. When it is
@@ -190,7 +200,13 @@ func NewFileLoggerWithMaxSize(file string, owner string, maxSize int64, maxBacku
 	rfWrapper := &rollingFileWrapper{rf}
 	runtime.SetFinalizer(rfWrapper, stopFlusher)
 	if err == nil {
-		logger = log.New(rfWrapper, "", log.Ldate|log.Ltime)
+		var writer io.Writer = rfWrapper
+		flags := log.Ldate | log.Ltime
+		if timeformat != "" {
+			writer = logWriter{Writer: rfWrapper, timeformat: timeformat}
+			flags = 0
+		}
+		logger = log.New(writer, "", flags)
 	} else {
 		fmt.Fprintf(os.Stderr, "WARNING: Unable to set up log file: %v\n", err)
 		logger = NewNilLogger()
@@ -213,13 +229,25 @@ func NewNilLogger() *log.Logger {
 }
 
 // NewConsoleErrorLogger is a basic logger to Stderr
-func NewConsoleErrorLogger() (logger *log.Logger) {
-	logger = log.New(os.Stderr, "", log.Ldate|log.Ltime)
+func NewConsoleErrorLogger(timeformat string) (logger *log.Logger) {
+	var writer io.Writer = os.Stderr
+	flags := log.Ldate | log.Ltime
+	if timeformat != "" {
+		writer = logWriter{Writer: os.Stderr, timeformat: timeformat}
+		flags = 0
+	}
+	logger = log.New(writer, "", flags)
 	return logger
 }
 
 // NewConsoleLogger is a basic logger to Stdout
-func NewConsoleLogger() (logger *log.Logger) {
-	logger = log.New(os.Stdout, "", log.Ldate|log.Ltime)
+func NewConsoleLogger(timeformat string) (logger *log.Logger) {
+	var writer io.Writer = os.Stdout
+	flags := log.Ldate | log.Ltime
+	if timeformat != "" {
+		writer = logWriter{Writer: os.Stdout, timeformat: timeformat}
+		flags = 0
+	}
+	logger = log.New(writer, "", flags)
 	return logger
 }

--- a/lib/logging/logging_test.go
+++ b/lib/logging/logging_test.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -11,13 +12,13 @@ import (
 func TestStandardLogging(t *testing.T) {
 	lname := fmt.Sprintf("%s/test-standard-log-%d.log", os.TempDir(), time.Now().Unix())
 
-	logger := NewFileLogger(lname, "")
+	logger := NewFileLogger(lname, "", "2006-01-02 15:04:05")
 	defer func() {
 		os.Remove(lname)
 	}()
 
 	msg := "TestStandardLogging"
-	logger.Printf(msg)
+	logger.Print(msg)
 	CloseAllOpenFileLoggers()
 
 	output, err := os.ReadFile(lname)
@@ -25,8 +26,43 @@ func TestStandardLogging(t *testing.T) {
 		t.Errorf("Unable to read file: %v", err)
 	}
 
-	if !strings.Contains(string(output), msg) {
-		t.Errorf("Expected '%s', got '%s'", msg, output)
+	outstr := string(output)
+	// Expect format: YYYY/MM/DD HH:MM:SS <msg>
+	re := regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} `)
+	if !re.MatchString(outstr) {
+		t.Errorf("expected timestamp prefix, got: %q", outstr)
+	}
+	if !strings.Contains(outstr, msg) {
+		t.Errorf("Expected '%s', got '%s'", msg, outstr)
+	}
+}
+
+
+func TestStandardTwelveHourLogging(t *testing.T) {
+	lname := fmt.Sprintf("%s/test-standard-log-%d.log", os.TempDir(), time.Now().Unix())
+
+	logger := NewFileLogger(lname, "", "2006/01/02 03:04:05 PM")
+	defer func() {
+		os.Remove(lname)
+	}()
+
+	msg := "TestStandardLogging"
+	logger.Print(msg)
+	CloseAllOpenFileLoggers()
+
+	output, err := os.ReadFile(lname)
+	if err != nil {
+		t.Errorf("Unable to read file: %v", err)
+	}
+
+	outstr := string(output)
+	// Expect format: YYYY/MM/DD HH:MM:SS <msg>
+	re := regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} [APM]{2} ` + msg)
+	if !re.MatchString(outstr) {
+		t.Errorf("expected timestamp prefix, got: %q", outstr)
+	}
+	if !strings.Contains(outstr, msg) {
+		t.Errorf("Expected '%s', got '%s'", msg, outstr)
 	}
 }
 
@@ -34,7 +70,7 @@ func TestRollingLog(t *testing.T) {
 	lname := fmt.Sprintf("%s/test-rolling-log-%d.log", os.TempDir(), time.Now().Unix())
 
 	// Create the logger with log rotation for max 5 backup files.
-	logger := NewFileLoggerWithMaxSize(lname, "", 1024, 5)
+	logger := NewFileLoggerWithMaxSize(lname, "", 1024, 5, "2006-01-02 15:04:05")
 	defer func() {
 		// Clean up all the log files after the test.
 		for i := 0; i <= 5; i++ { // Remove the main log file and the 5 backups.
@@ -74,9 +110,8 @@ func TestRollingLog(t *testing.T) {
 
 func TestRollingLogFlush_IsFlushed(t *testing.T) {
 	// Arrange
-	//lname := fmt.Sprintf("%s/test-flushed-log-%d.log", os.TempDir(), time.Now().Unix())
 	lname := fmt.Sprintf("test-flushed-log-%d.log", time.Now().Unix())
-	logger := NewFileLoggerWithMaxSize(lname, "", 10024, 5)
+	logger := NewFileLoggerWithMaxSize(lname, "", 10024, 5, "2006-01-02 15:04:05")
 	defer func() {
 		CloseAllOpenFileLoggers()
 		os.Remove(lname)

--- a/lib/logging/logging_test.go
+++ b/lib/logging/logging_test.go
@@ -27,7 +27,7 @@ func TestStandardLogging(t *testing.T) {
 	}
 
 	outstr := string(output)
-	// Expect format: YYYY/MM/DD HH:MM:SS <msg>
+	// Expect format: YYYY-MM-DD HH:MM:SS <msg>
 	re := regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} `)
 	if !re.MatchString(outstr) {
 		t.Errorf("expected timestamp prefix, got: %q", outstr)
@@ -36,7 +36,6 @@ func TestStandardLogging(t *testing.T) {
 		t.Errorf("Expected '%s', got '%s'", msg, outstr)
 	}
 }
-
 
 func TestStandardTwelveHourLogging(t *testing.T) {
 	lname := fmt.Sprintf("%s/test-standard-log-%d.log", os.TempDir(), time.Now().Unix())
@@ -56,7 +55,7 @@ func TestStandardTwelveHourLogging(t *testing.T) {
 	}
 
 	outstr := string(output)
-	// Expect format: YYYY/MM/DD HH:MM:SS <msg>
+	// Expect format: YYYY/MM/DD HH:MM:SS [AM|PM] <msg>
 	re := regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} [APM]{2} ` + msg)
 	if !re.MatchString(outstr) {
 		t.Errorf("expected timestamp prefix, got: %q", outstr)

--- a/lib/logging/owner_unix_test.go
+++ b/lib/logging/owner_unix_test.go
@@ -23,7 +23,27 @@ func TestLogIsOwnedByCorrectUser(t *testing.T) {
 
 	lname := fmt.Sprintf("%s/test-standard-log-%d.log", os.TempDir(), time.Now().Unix())
 
-	logger := NewFileLogger(lname, userName)
+	logger := NewFileLogger(lname, userName, "2006-01-02 15:04:05")
+	"os"
+	"testing"
+	"time"
+)
+
+func TestLogIsOwnedByCorrectUser(t *testing.T) {
+	userName := "correct_user"
+
+	functionCalled := false
+	// Mock the function
+	changeOwnerOfFileFunc = func(name string, owner string) error {
+		if owner == userName {
+			functionCalled = true
+		}
+		return nil
+	}
+
+	lname := fmt.Sprintf("%s/test-standard-log-%d.log", os.TempDir(), time.Now().Unix())
+
+	logger := NewFileLogger(lname, userName, "2006-01-02 15:04:05")
 	defer func() {
 		os.Remove(lname)
 	}()

--- a/lib/logging/owner_unix_test.go
+++ b/lib/logging/owner_unix_test.go
@@ -24,26 +24,6 @@ func TestLogIsOwnedByCorrectUser(t *testing.T) {
 	lname := fmt.Sprintf("%s/test-standard-log-%d.log", os.TempDir(), time.Now().Unix())
 
 	logger := NewFileLogger(lname, userName, "2006-01-02 15:04:05")
-	"os"
-	"testing"
-	"time"
-)
-
-func TestLogIsOwnedByCorrectUser(t *testing.T) {
-	userName := "correct_user"
-
-	functionCalled := false
-	// Mock the function
-	changeOwnerOfFileFunc = func(name string, owner string) error {
-		if owner == userName {
-			functionCalled = true
-		}
-		return nil
-	}
-
-	lname := fmt.Sprintf("%s/test-standard-log-%d.log", os.TempDir(), time.Now().Unix())
-
-	logger := NewFileLogger(lname, userName, "2006-01-02 15:04:05")
 	defer func() {
 		os.Remove(lname)
 	}()

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -212,10 +212,6 @@ func (conf *Config) applyDefaults() {
 		conf.EnvironmentVars = make(map[string]string)
 	}
 
-	if conf.ServiceConfig.LogFileTimestampFormat == "" {
-		conf.ServiceConfig.LogFileTimestampFormat = "2006-01-02 15:04:05"
-	}
-
 	// Default graceful is 5 seconds
 	for i := range conf.Services {
 		if conf.Services[i].GracefulShutdownTimeoutSecs == 0 {

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -40,14 +40,15 @@ type ServiceDescription struct {
 }
 
 type ServiceConfig struct {
-	StopFile              string
-	ReloadFile            string
-	LogFile               string
-	LogFileMaxSizeMb      int64
-	LogFileMaxBackupFiles int
-	PidFile               string
-	UserLevel             bool
-	UserName              string
+	StopFile               string
+	ReloadFile             string
+	LogFile                string
+	LogFileMaxSizeMb       int64
+	LogFileMaxBackupFiles  int
+	PidFile                string
+	UserLevel              bool
+	UserName               string
+	LogFileTimestampFormat string
 }
 
 type command struct {
@@ -209,6 +210,10 @@ func (conf *Config) applyDefaults() {
 
 	if conf.EnvironmentVars == nil {
 		conf.EnvironmentVars = make(map[string]string)
+	}
+
+	if conf.ServiceConfig.LogFileTimestampFormat == "" {
+		conf.ServiceConfig.LogFileTimestampFormat = "2006-01-02 15:04:05"
 	}
 
 	// Default graceful is 5 seconds

--- a/service/main_logging_test.go
+++ b/service/main_logging_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/papercutsoftware/silver/lib/logging"
+	"github.com/papercutsoftware/silver/service/config"
+)
+
+func TestLogging_SampleConfigWithDefaultDateFormat(t *testing.T) {
+	cfg := loadTestConfig(t, "logging-defaultdateformat.conf")
+	logPath := filepath.Join(t.TempDir(), "no-micro.log")
+	cfg.ServiceConfig.LogFile = logPath
+
+	logger := logging.NewFileLogger(cfg.ServiceConfig.LogFile, cfg.ServiceConfig.UserName, cfg.ServiceConfig.LogFileTimestampFormat)
+	t.Cleanup(logging.CloseAllOpenFileLoggers)
+
+	testmessage := "LoggingWithDefaultDateFormat"
+	logger.Printf("%s %s", testmessage, cfg.ServiceConfig.LogFileTimestampFormat)
+	logging.CloseAllOpenFileLoggers()
+
+	data, err := os.ReadFile(cfg.ServiceConfig.LogFile)
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+	line := string(data)
+
+	reDate := regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} `)
+	if !reDate.MatchString(line) {
+		t.Fatalf("expected timestamp without microseconds, got %q", line)
+	}
+
+	reMicro := regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6} `)
+	if reMicro.MatchString(line) {
+		t.Fatalf("did not expect microsecond precision, got %q", line)
+	}
+
+	if !strings.Contains(line, testmessage) {
+		t.Fatalf("expected log line to contain %q, got %q", testmessage, line)
+	}
+}
+
+func TestLogging_SampleConfigWithMicroseconds(t *testing.T) {
+	cfg := loadTestConfig(t, "logging-with-microseconds.conf")
+	logPath := filepath.Join(t.TempDir(), "with-micro.log")
+	cfg.ServiceConfig.LogFile = logPath
+
+	logger := logging.NewFileLogger(cfg.ServiceConfig.LogFile, cfg.ServiceConfig.UserName, cfg.ServiceConfig.LogFileTimestampFormat)
+	t.Cleanup(logging.CloseAllOpenFileLoggers)
+
+	testmessage := "LoggingWithMicroseconds"
+	msg := "%s %s"
+	logger.Printf(msg, testmessage, cfg.ServiceConfig.LogFileTimestampFormat)
+	logging.CloseAllOpenFileLoggers()
+
+	data, err := os.ReadFile(cfg.ServiceConfig.LogFile)
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+	line := string(data)
+
+	re := regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6} `)
+	if !re.MatchString(line) {
+		t.Fatalf("expected microsecond precision, got %q", line)
+	}
+
+	if !strings.Contains(line, testmessage) {
+		t.Fatalf("expected log line to contain %q, got %q", testmessage, line)
+	}
+}
+
+func loadTestConfig(t *testing.T, filename string) *config.Config {
+	t.Helper()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("unable to resolve current file path")
+	}
+	baseDir := filepath.Dir(currentFile)
+	path := filepath.Join(baseDir, "testdata", filename)
+
+	vars := config.ReplacementVars{
+		ServiceName: "silver-test",
+		ServiceRoot: t.TempDir(),
+	}
+
+	cfg, err := config.LoadConfig(path, vars)
+	if err != nil {
+		t.Fatalf("loading config %s: %v", path, err)
+	}
+
+	return cfg
+}

--- a/service/main_logging_test.go
+++ b/service/main_logging_test.go
@@ -30,14 +30,9 @@ func TestLogging_SampleConfigWithDefaultDateFormat(t *testing.T) {
 	}
 	line := string(data)
 
-	reDate := regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} `)
+	reDate := regexp.MustCompile(`^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} `)
 	if !reDate.MatchString(line) {
-		t.Fatalf("expected timestamp without microseconds, got %q", line)
-	}
-
-	reMicro := regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6} `)
-	if reMicro.MatchString(line) {
-		t.Fatalf("did not expect microsecond precision, got %q", line)
+		t.Fatalf("expected default date format without microseconds, got %q", line)
 	}
 
 	if !strings.Contains(line, testmessage) {

--- a/service/testdata/logging-defaultdateformat.conf
+++ b/service/testdata/logging-defaultdateformat.conf
@@ -1,0 +1,14 @@
+{
+  "ServiceDescription": {
+    "DisplayName": "Test Service With default Date Format",
+    "Description": "Test config for logging with default date format"
+  },
+  "ServiceConfig": {
+    "LogFile": "${ServiceName}.log"
+  },
+  "Services": [
+    {
+      "Path": "test/path"
+    }
+  ]
+}

--- a/service/testdata/logging-with-microseconds.conf
+++ b/service/testdata/logging-with-microseconds.conf
@@ -1,0 +1,15 @@
+{
+  "ServiceDescription": {
+    "DisplayName": "Test Service With Microseconds",
+    "Description": "Test config for logging with microsecond precision"
+  },
+  "ServiceConfig": {
+    "LogFile": "${ServiceName}.log",
+    "LogFileTimestampFormat": "2006-01-02 15:04:05.000000"
+  },
+  "Services": [
+    {
+      "Path": "test/path"
+    }
+  ]
+}


### PR DESCRIPTION
By request from @tinhtruong I have made an alternative to "LogFileTimestampMicroseconds" and instead introduced a "LogFileTimestampFormat" giving the customers complete control of the format.