### PR TITLE
Fix jsonsig issues

### DIFF
--- a/lib/jsonsig/jsonsig.go
+++ b/lib/jsonsig/jsonsig.go
@@ -56,7 +56,7 @@ func Sign(payload []byte, privateKeyB64 string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to canonicalize payload: %w", err)
 	}
 
-	privateKey, err := base64.StdEncoding.DecodeString(privateKeyB64)
+	privateKey, err := base64.StdEncoding.Strict().DecodeString(privateKeyB64)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func Sign(payload []byte, privateKeyB64 string) ([]byte, error) {
 // Verify takes a signed JSON payload and a base64 encoded public key, and returns
 // true if the signature is valid.
 func Verify(signedPayload []byte, publicKeyB64 string) (bool, error) {
-	publicKey, err := base64.StdEncoding.DecodeString(publicKeyB64)
+	publicKey, err := base64.StdEncoding.Strict().DecodeString(publicKeyB64)
 	if err != nil {
 		return false, err
 	}
@@ -88,7 +88,7 @@ func Verify(signedPayload []byte, publicKeyB64 string) (bool, error) {
 		return false, fmt.Errorf("invalid signature format: 'signature' field missing or not a string")
 	}
 
-	signature, err := base64.StdEncoding.DecodeString(signatureB64)
+	signature, err := base64.StdEncoding.Strict().DecodeString(signatureB64)
 	if err != nil {
 		return false, fmt.Errorf("failed to decode base64 signature: %w", err)
 	}

--- a/lib/jsonsig/jsonsig.go
+++ b/lib/jsonsig/jsonsig.go
@@ -82,8 +82,8 @@ func Verify(signedPayload []byte, publicKeyB64 string) (bool, error) {
 		return false, fmt.Errorf("invalid public key size: expected %d bytes, got %d", ed25519.PublicKeySize, len(publicKey))
 	}
 
-	// This call is a sanity check to ensure the JSON input is well-formed and does not contain duplicate keys, which
-	// could lead to security issues.
+	// This call is a sanity check to ensure the JSON input is well-formed and does not have any malformed structure,
+	// which could lead to security issues.
 	if _, err := jcs.Transform(signedPayload); err != nil {
 		return false, fmt.Errorf("invalid payload structure: potential duplicate keys or malformed JSON: %w", err)
 	}

--- a/lib/jsonsig/jsonsig.go
+++ b/lib/jsonsig/jsonsig.go
@@ -78,6 +78,10 @@ func Verify(signedPayload []byte, publicKeyB64 string) (bool, error) {
 		return false, err
 	}
 
+	if len(publicKey) != ed25519.PublicKeySize {
+		return false, fmt.Errorf("invalid public key size: expected %d bytes, got %d", ed25519.PublicKeySize, len(publicKey))
+	}
+
 	// This call is a sanity check to ensure the JSON input is well-formed and does not contain duplicate keys, which
 	// could lead to security issues.
 	if _, err := jcs.Transform(signedPayload); err != nil {
@@ -97,6 +101,9 @@ func Verify(signedPayload []byte, publicKeyB64 string) (bool, error) {
 	signature, err := base64.StdEncoding.Strict().DecodeString(signatureB64)
 	if err != nil {
 		return false, fmt.Errorf("failed to decode base64 signature: %w", err)
+
+	if len(signature) != ed25519.SignatureSize {
+		return false, fmt.Errorf("invalid signature size: expected %d bytes, got %d", ed25519.SignatureSize, len(signature))
 	}
 
 	delete(m, "signature")

--- a/lib/jsonsig/jsonsig.go
+++ b/lib/jsonsig/jsonsig.go
@@ -78,6 +78,12 @@ func Verify(signedPayload []byte, publicKeyB64 string) (bool, error) {
 		return false, err
 	}
 
+	// This call is a sanity check to ensure the JSON input is well-formed and does not contain duplicate keys, which
+	// could lead to security issues.
+	if _, err := jcs.Transform(signedPayload); err != nil {
+		return false, fmt.Errorf("invalid payload structure: potential duplicate keys or malformed JSON: %w", err)
+	}
+
 	var m map[string]any
 	if err := unmarshalJSON(signedPayload, &m); err != nil {
 		return false, fmt.Errorf("payload must be a JSON object: %w", err)

--- a/lib/jsonsig/jsonsig.go
+++ b/lib/jsonsig/jsonsig.go
@@ -1,7 +1,7 @@
 // SILVER - Service Wrapper
 // Auto Updater
 //
-// Copyright (c) 2014-2025 PaperCut Software http://www.papercut.com/
+// Copyright (c) 2014-2026 PaperCut Software http://www.papercut.com/
 // Use of this source code is governed by an MIT or GPL Version 2 license.
 // See the project's LICENSE file for more information.
 //
@@ -12,6 +12,7 @@
 package jsonsig
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
@@ -39,8 +40,8 @@ func GenerateKeys() (string, string, error) {
 // signed JSON payload. The signature is added to the JSON payload in a "signature" field.
 func Sign(payload []byte, privateKeyB64 string) ([]byte, error) {
 	// Validate we've got a valid JSON object.
-	var m map[string]interface{}
-	if err := json.Unmarshal(payload, &m); err != nil {
+	var m map[string]any
+	if err := unmarshalJSON(payload, &m); err != nil {
 		return nil, fmt.Errorf("payload must be a JSON object (e.g {...}): %w", err)
 	}
 
@@ -77,8 +78,8 @@ func Verify(signedPayload []byte, publicKeyB64 string) (bool, error) {
 		return false, err
 	}
 
-	var m map[string]interface{}
-	if err := json.Unmarshal(signedPayload, &m); err != nil {
+	var m map[string]any
+	if err := unmarshalJSON(signedPayload, &m); err != nil {
 		return false, fmt.Errorf("payload must be a JSON object: %w", err)
 	}
 
@@ -112,4 +113,11 @@ func Verify(signedPayload []byte, publicKeyB64 string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// unmarshalJSON deserializes a JSON byte slice while preserving the precision of large numbers.
+func unmarshalJSON(data []byte, m *map[string]any) error {
+	d := json.NewDecoder(bytes.NewReader(data))
+	d.UseNumber()
+	return d.Decode(m)
 }

--- a/lib/jsonsig/jsonsig.go
+++ b/lib/jsonsig/jsonsig.go
@@ -53,7 +53,7 @@ func Sign(payload []byte, privateKeyB64 string) ([]byte, error) {
 	// Canonicalize the payload that we will sign.
 	canonicalPayload, err := jcs.Transform(payload)
 	if err != nil {
-		return nil, fmt.Errorf("failed to canonicalize payload: %w", err)
+		return nil, fmt.Errorf("canonicalize payload: %w", err)
 	}
 
 	privateKey, err := base64.StdEncoding.Strict().DecodeString(privateKeyB64)
@@ -100,7 +100,8 @@ func Verify(signedPayload []byte, publicKeyB64 string) (bool, error) {
 
 	signature, err := base64.StdEncoding.Strict().DecodeString(signatureB64)
 	if err != nil {
-		return false, fmt.Errorf("failed to decode base64 signature: %w", err)
+		return false, fmt.Errorf("decode base64 signature: %w", err)
+	}
 
 	if len(signature) != ed25519.SignatureSize {
 		return false, fmt.Errorf("invalid signature size: expected %d bytes, got %d", ed25519.SignatureSize, len(signature))
@@ -113,12 +114,12 @@ func Verify(signedPayload []byte, publicKeyB64 string) (bool, error) {
 	// canonicalizing that.
 	unsignedPayload, err := json.Marshal(m)
 	if err != nil {
-		return false, fmt.Errorf("failed to marshal unsigned payload: %w", err)
+		return false, fmt.Errorf("marshal unsigned payload: %w", err)
 	}
 
 	canonicalPayload, err := jcs.Transform(unsignedPayload)
 	if err != nil {
-		return false, fmt.Errorf("failed to canonicalize payload for verification: %w", err)
+		return false, fmt.Errorf("canonicalize payload for verification: %w", err)
 	}
 
 	if !ed25519.Verify(publicKey, canonicalPayload, signature) {

--- a/lib/jsonsig/jsonsig_test.go
+++ b/lib/jsonsig/jsonsig_test.go
@@ -283,3 +283,56 @@ func TestBase64PaddingMalleability(t *testing.T) {
 		t.Error("VULNERABILITY: Verify returned true for malleable base64 signature!")
 	}
 }
+
+func TestTrailingDataRejection(t *testing.T) {
+	publicKey, privateKey, err := GenerateKeys()
+	if err != nil {
+		t.Fatalf("Failed to generate keys: %v", err)
+	}
+	payload := []byte(`{"foo": "bar"}`)
+	signedPayload, err := Sign(payload, privateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign payload: %v", err)
+	}
+
+	t.Run("trailing whitespace is allowed", func(t *testing.T) {
+		payloadWithWhitespace := append(signedPayload, []byte(" \n\t ")...)
+		valid, err := Verify(payloadWithWhitespace, publicKey)
+		if err != nil {
+			t.Errorf("Expected success for trailing whitespace, got error: %v", err)
+		}
+		if !valid {
+			t.Error("Expected valid=true for trailing whitespace, got false")
+		}
+	})
+
+	t.Run("trailing garbage is rejected", func(t *testing.T) {
+		payloadWithGarbage := append(signedPayload, []byte("garbage")...)
+		valid, err := Verify(payloadWithGarbage, publicKey)
+		if err == nil {
+			t.Error("Expected error for trailing garbage, got nil")
+		}
+		if valid {
+			t.Error("Expected valid=false for trailing garbage, got true")
+		}
+	})
+
+	t.Run("multiple top level JSON values are rejected", func(t *testing.T) {
+		multipleJSON := append(signedPayload, []byte(`{"foo": "malicious"}`)...)
+		valid, err := Verify(multipleJSON, publicKey)
+		if err == nil {
+			t.Error("Expected error for multiple top level JSON values, got nil")
+		}
+		if valid {
+			t.Error("Expected valid=false for multiple top level JSON values, got true")
+		}
+	})
+
+	t.Run("Sign rejects trailing garbage", func(t *testing.T) {
+		payloadWithGarbage := []byte(`{"foo": "bar"}garbage`)
+		_, err := Sign(payloadWithGarbage, privateKey)
+		if err == nil {
+			t.Error("Expected Sign to fail for payload with trailing garbage, got nil error")
+		}
+	})
+}

--- a/lib/jsonsig/jsonsig_test.go
+++ b/lib/jsonsig/jsonsig_test.go
@@ -1,7 +1,7 @@
 // SILVER - Service Wrapper
 // Auto Updater
 //
-// Copyright (c) 2014-2025 PaperCut Software http://www.papercut.com/
+// Copyright (c) 2014-2026 PaperCut Software http://www.papercut.com/
 // Use of this source code is governed by an MIT or GPL Version 2 license.
 // See the project's LICENSE file for more information.
 //
@@ -9,6 +9,9 @@
 package jsonsig
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -115,5 +118,169 @@ func TestSignFailureWithExistingSignature(t *testing.T) {
 	_, err = Sign(payload, privateKey)
 	if err == nil {
 		t.Error("Signing should have failed because a signature field already exists, but it did not.")
+	}
+}
+
+func TestLargeIntegerIncompatibility(t *testing.T) {
+	publicKey, privateKey, err := GenerateKeys()
+	if err != nil {
+		t.Fatalf("Failed to generate keys: %v", err)
+	}
+
+	// Large integer payload, the value must be larger than 52 bits integer.
+	payload := []byte(`{"value": 12345678901234567890}`)
+
+	signedPayload, err := Sign(payload, privateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign payload: %v", err)
+	}
+
+	if !strings.Contains(string(signedPayload), "12345678901234567890") {
+		t.Errorf("Precision lost: expected signed payload to contain 12345678901234567890, but got:\n%s", string(signedPayload))
+	}
+
+	valid, err := Verify(signedPayload, publicKey)
+	if err != nil {
+		t.Fatalf("Failed to verify: %v", err)
+	}
+	if !valid {
+		t.Error("Verification failed for large integer payload")
+	}
+}
+
+func TestDuplicateKeyBypass(t *testing.T) {
+	publicKey, privateKey, err := GenerateKeys()
+	if err != nil {
+		t.Fatalf("Failed to generate keys: %v", err)
+	}
+
+	payload := []byte(`{"foo": "bar"}`)
+
+	signedPayload, err := Sign(payload, privateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign payload: %v", err)
+	}
+
+	// Now we tamper with the signed payload by inserting a duplicate "foo" key with a different value
+	// at the beginning of the JSON object.
+	// Original is something like:
+	// {
+	//     "foo": "bar",
+	//     "signature": "..."
+	// }
+	// We make it:
+	// {
+	//     "foo": "malicious",
+	//     "foo": "bar",
+	//     "signature": "..."
+	// }
+	// This is a malicious payload that should fail verification, or if verified, the signature should protect the whole payload bytes.
+	// But let's see if Verify returns true.
+	tamperedPayload := []byte(`{
+"foo": "malicious",
+"foo": "bar",
+"signature": "
+`)
+
+	// Extract signature from signedPayload
+	var m map[string]any
+	if err := json.Unmarshal(signedPayload, &m); err != nil {
+		t.Fatalf("Failed to parse signedPayload: %v", err)
+	}
+	sig, _ := m["signature"].(string)
+
+	tamperedPayload = append(tamperedPayload, []byte(sig)...)
+	tamperedPayload = append(tamperedPayload, []byte(`"}`)...)
+
+	valid, err := Verify(tamperedPayload, publicKey)
+	if err == nil && valid {
+		t.Error("VULNERABILITY: Verify returned true for a tampered payload with duplicate keys!")
+	}
+}
+
+func TestVerifyPanicWithInvalidLengths(t *testing.T) {
+	publicKey, privateKey, err := GenerateKeys()
+	if err != nil {
+		t.Fatalf("Failed to generate keys: %v", err)
+	}
+	payload := []byte(`{"foo": "bar"}`)
+	signedPayload, err := Sign(payload, privateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign payload: %v", err)
+	}
+
+	t.Run("invalid short public key", func(t *testing.T) {
+		shortPublicKey := base64.StdEncoding.EncodeToString([]byte("too_short"))
+		_, err = Verify(signedPayload, shortPublicKey)
+		if err == nil {
+			t.Error("Expected error for short public key, got nil")
+		}
+	})
+
+	// Invalid short signature in the payload (e.g., "dG9vX3Nob3J0" = "too_short")
+	t.Run("invalid short signature", func(t *testing.T) {
+		tamperedPayload := []byte(`{"foo": "bar", "signature": "dG9vX3Nob3J0"}`)
+		_, err = Verify(tamperedPayload, publicKey)
+		if err == nil {
+			t.Error("Expected error for short signature, got nil")
+		}
+	})
+}
+
+func TestBase64PaddingMalleability(t *testing.T) {
+	publicKey, privateKey, err := GenerateKeys()
+	if err != nil {
+		t.Fatalf("Failed to generate keys: %v", err)
+	}
+	payload := []byte(`{"foo": "bar"}`)
+	signedPayload, err := Sign(payload, privateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign payload: %v", err)
+	}
+
+	// Parse the signature from signedPayload
+	var m map[string]any
+	if err := json.Unmarshal(signedPayload, &m); err != nil {
+		t.Fatalf("Failed to parse signedPayload: %v", err)
+	}
+	sig, _ := m["signature"].(string)
+
+	// Since a 64-byte signature encoded in standard base64 has 88 characters ending with "==",
+	// the character at index 85 (immediately preceding "==") has 4 unused bits.
+	if len(sig) < 88 || !strings.HasSuffix(sig, "==") {
+		t.Fatalf("Expected signature to be at least 88 chars and end with ==, got %s (len %d)", sig, len(sig))
+	}
+
+	lastCharIdx := len(sig) - 3 // character right before "=="
+	origChar := sig[lastCharIdx]
+
+	// Find another character in the same 16-character group
+	chars := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+	origIdx := strings.IndexByte(chars, origChar)
+	if origIdx == -1 {
+		t.Fatalf("Character %q not found in base64 alphabet", origChar)
+	}
+
+	// Change the character to a different one in the same 16-character boundary.
+	// For example, flip the least significant bit of origIdx.
+	newIdx := origIdx ^ 1
+	newChar := chars[newIdx]
+
+	// Create malleable signature
+	sigRunes := []rune(sig)
+	sigRunes[lastCharIdx] = rune(newChar)
+	malleableSig := string(sigRunes)
+
+	// Build the tampered payload with the malleable signature
+	m["signature"] = malleableSig
+	tamperedPayload, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("Failed to marshal tampered payload: %v", err)
+	}
+
+	// Try to verify
+	valid, err := Verify(tamperedPayload, publicKey)
+	if err == nil && valid {
+		t.Error("VULNERABILITY: Verify returned true for malleable base64 signature!")
 	}
 }

--- a/lib/jsonsig/jsonsig_test.go
+++ b/lib/jsonsig/jsonsig_test.go
@@ -198,7 +198,7 @@ func TestDuplicateKeyBypass(t *testing.T) {
 	}
 }
 
-func TestVerifyPanicWithInvalidLengths(t *testing.T) {
+func TestVerifyErrorWithInvalidLengths(t *testing.T) {
 	publicKey, privateKey, err := GenerateKeys()
 	if err != nil {
 		t.Fatalf("Failed to generate keys: %v", err)

--- a/lib/jsonsig/jsonsig_test.go
+++ b/lib/jsonsig/jsonsig_test.go
@@ -179,8 +179,7 @@ func TestDuplicateKeyBypass(t *testing.T) {
 	tamperedPayload := []byte(`{
 "foo": "malicious",
 "foo": "bar",
-"signature": "
-`)
+"signature": "`)
 
 	// Extract signature from signedPayload
 	var m map[string]any


### PR DESCRIPTION
I've fixed a couple of issues we found in `jsonsig`.

* Validate input public key and signature sizes
* Prevent signature bypass with duplicate JSON keys
* Use strict base64 decoding to prevent malleability attacks
* Prevent loss of precision for large JSON numbers