### PR TITLE
feat: send OS context headers on update check requests

### DIFF
--- a/updater/update/export_test.go
+++ b/updater/update/export_test.go
@@ -12,4 +12,5 @@ package update
 var (
 	SetOSHeaders         = setOSHeaders
 	TrimToNumericVersion = trimToNumericVersion
+	UserAgent            = userAgent
 )

--- a/updater/update/export_test.go
+++ b/updater/update/export_test.go
@@ -1,0 +1,15 @@
+// SILVER - Service Wrapper
+// Auto Updater
+//
+// Copyright (c) 2026 PaperCut Software http://www.papercut.com/
+// Use of this source code is governed by an MIT or GPL Version 2 license.
+// See the project's LICENSE file for more information.
+//
+
+package update
+
+// Test-only exports for black-box tests in package update_test.
+var (
+	SetOSHeaders         = setOSHeaders
+	TrimToNumericVersion = trimToNumericVersion
+)

--- a/updater/update/osinfo.go
+++ b/updater/update/osinfo.go
@@ -11,6 +11,7 @@ package update
 import (
 	"net/http"
 	"runtime"
+	"strings"
 )
 
 const (
@@ -19,6 +20,19 @@ const (
 	headerOSArchKey       string = "X-OS-Arch"
 	headerOSNativeArchKey string = "X-OS-Native-Arch"
 )
+
+// trimToNumericVersion trims a version string to its leading dot-separated
+// numeric part, dropping suffixes like the distro patch, kernel flavor and
+// architecture in a Linux kernel release ("5.15.0-91-generic" → "5.15.0").
+// The update server compares versions segment-by-segment numerically, so
+// only digits and dots may be sent.
+func trimToNumericVersion(version string) string {
+	end := 0
+	for end < len(version) && (version[end] == '.' || ('0' <= version[end] && version[end] <= '9')) {
+		end++
+	}
+	return strings.TrimRight(version[:end], ".")
+}
 
 // addOSContextToRequestHeader adds OS identity headers used by the update
 // server to select a build compatible with this host. GOOS and GOARCH are

--- a/updater/update/osinfo.go
+++ b/updater/update/osinfo.go
@@ -25,8 +25,6 @@ const (
 // trimToNumericVersion trims a version string to its leading dot-separated
 // numeric part, dropping suffixes like the distro patch, kernel flavor and
 // architecture in a Linux kernel release ("5.15.0-91-generic" → "5.15.0").
-// The update server compares versions segment-by-segment numerically, so
-// only digits and dots may be sent.
 func trimToNumericVersion(version string) string {
 	end := 0
 	for end < len(version) && (version[end] == '.' || ('0' <= version[end] && version[end] <= '9')) {
@@ -35,11 +33,10 @@ func trimToNumericVersion(version string) string {
 	return strings.TrimRight(version[:end], ".")
 }
 
-// setOSHeaders sets the OS identity headers used by the update server to
-// select a build compatible with this host. The server keys build selection
-// on X-OS-Type + X-OS-Arch; X-Binary-Arch reports what the running updater
-// was compiled for, which differs from X-OS-Arch under emulation (Rosetta 2,
-// Windows-on-ARM) so those installs migrate to native builds.
+// setOSHeaders sets headers identifying this host's OS and architecture.
+// X-OS-Type and X-OS-Arch describe the host itself; X-Binary-Arch reports
+// what the running updater was compiled for, which differs from X-OS-Arch
+// under emulation (Rosetta 2, Windows-on-ARM).
 func setOSHeaders(req *http.Request) {
 	req.Header.Set(headerOSTypeKey, runtime.GOOS)
 	// Best-effort host architecture: detects Rosetta 2 and Windows-on-ARM

--- a/updater/update/osinfo.go
+++ b/updater/update/osinfo.go
@@ -34,10 +34,10 @@ func trimToNumericVersion(version string) string {
 	return strings.TrimRight(version[:end], ".")
 }
 
-// addOSContextToRequestHeader adds OS identity headers used by the update
-// server to select a build compatible with this host. GOOS and GOARCH are
-// sent verbatim so no OS/arch mapping code ships in the client.
-func addOSContextToRequestHeader(req *http.Request) {
+// setOSHeaders sets the OS identity headers used by the update server to
+// select a build compatible with this host. GOOS and GOARCH are sent
+// verbatim so no OS/arch mapping code ships in the client.
+func setOSHeaders(req *http.Request) {
 	req.Header.Set(headerOSTypeKey, runtime.GOOS)
 	req.Header.Set(headerOSArchKey, runtime.GOARCH)
 	// Host architecture; differs from X-OS-Arch when running under

--- a/updater/update/osinfo.go
+++ b/updater/update/osinfo.go
@@ -44,7 +44,7 @@ func addOSContextToRequestHeader(req *http.Request) {
 	// emulation (Rosetta 2, Windows-on-ARM).
 	req.Header.Set(headerOSNativeArchKey, nativeArch())
 	// Best effort: an unknown OS version is better than a failed update check.
-	if version, err := osVersion(); err == nil && version != "" {
+	if version, err := osVersion(); err == nil {
 		req.Header.Set(headerOSVersionKey, version)
 	}
 }

--- a/updater/update/osinfo.go
+++ b/updater/update/osinfo.go
@@ -1,0 +1,32 @@
+// SILVER - Service Wrapper
+// Auto Updater
+//
+// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Use of this source code is governed by an MIT or GPL Version 2 license.
+// See the project's LICENSE file for more information.
+//
+
+package update
+
+import (
+	"net/http"
+	"runtime"
+)
+
+const (
+	headerOSTypeKey    string = "X-OS-Type"
+	headerOSVersionKey string = "X-OS-Version"
+	headerOSArchKey    string = "X-OS-Arch"
+)
+
+// addOSContextToRequestHeader adds OS identity headers used by the update
+// server to select a build compatible with this host. GOOS and GOARCH are
+// sent verbatim so no OS/arch mapping code ships in the client.
+func addOSContextToRequestHeader(req *http.Request) {
+	req.Header.Set(headerOSTypeKey, runtime.GOOS)
+	req.Header.Set(headerOSArchKey, runtime.GOARCH)
+	// Best effort: an unknown OS version is better than a failed update check.
+	if version, err := osVersion(); err == nil && version != "" {
+		req.Header.Set(headerOSVersionKey, version)
+	}
+}

--- a/updater/update/osinfo.go
+++ b/updater/update/osinfo.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	headerOSTypeKey       string = "X-OS-Type"
-	headerOSVersionKey    string = "X-OS-Version"
-	headerOSArchKey       string = "X-OS-Arch"
-	headerOSNativeArchKey string = "X-OS-Native-Arch"
+	headerOSTypeKey     string = "X-OS-Type"
+	headerOSVersionKey  string = "X-OS-Version"
+	headerOSArchKey     string = "X-OS-Arch"
+	headerBinaryArchKey string = "X-Binary-Arch"
 )
 
 // trimToNumericVersion trims a version string to its leading dot-separated
@@ -36,14 +36,16 @@ func trimToNumericVersion(version string) string {
 }
 
 // setOSHeaders sets the OS identity headers used by the update server to
-// select a build compatible with this host. GOOS and GOARCH are sent
-// verbatim so no OS/arch mapping code ships in the client.
+// select a build compatible with this host. The server keys build selection
+// on X-OS-Type + X-OS-Arch; X-Binary-Arch reports what the running updater
+// was compiled for, which differs from X-OS-Arch under emulation (Rosetta 2,
+// Windows-on-ARM) so those installs migrate to native builds.
 func setOSHeaders(req *http.Request) {
 	req.Header.Set(headerOSTypeKey, runtime.GOOS)
-	req.Header.Set(headerOSArchKey, runtime.GOARCH)
-	// Host architecture; differs from X-OS-Arch when running under
-	// emulation (Rosetta 2, Windows-on-ARM).
-	req.Header.Set(headerOSNativeArchKey, nativeArch())
+	// Best-effort host architecture: detects Rosetta 2 and Windows-on-ARM
+	// emulation; on other platforms falls back to the binary's arch.
+	req.Header.Set(headerOSArchKey, nativeArch())
+	req.Header.Set(headerBinaryArchKey, runtime.GOARCH)
 	// Best effort: an unknown OS version is better than a failed update check.
 	if version, err := osVersion(); err == nil {
 		req.Header.Set(headerOSVersionKey, version)

--- a/updater/update/osinfo.go
+++ b/updater/update/osinfo.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	headerOSTypeKey    string = "X-OS-Type"
-	headerOSVersionKey string = "X-OS-Version"
-	headerOSArchKey    string = "X-OS-Arch"
+	headerOSTypeKey       string = "X-OS-Type"
+	headerOSVersionKey    string = "X-OS-Version"
+	headerOSArchKey       string = "X-OS-Arch"
+	headerOSNativeArchKey string = "X-OS-Native-Arch"
 )
 
 // addOSContextToRequestHeader adds OS identity headers used by the update
@@ -25,6 +26,9 @@ const (
 func addOSContextToRequestHeader(req *http.Request) {
 	req.Header.Set(headerOSTypeKey, runtime.GOOS)
 	req.Header.Set(headerOSArchKey, runtime.GOARCH)
+	// Host architecture; differs from X-OS-Arch when running under
+	// emulation (Rosetta 2, Windows-on-ARM).
+	req.Header.Set(headerOSNativeArchKey, nativeArch())
 	// Best effort: an unknown OS version is better than a failed update check.
 	if version, err := osVersion(); err == nil && version != "" {
 		req.Header.Set(headerOSVersionKey, version)

--- a/updater/update/osinfo.go
+++ b/updater/update/osinfo.go
@@ -9,6 +9,7 @@
 package update
 
 import (
+	"fmt"
 	"net/http"
 	"runtime"
 	"strings"
@@ -46,5 +47,7 @@ func setOSHeaders(req *http.Request) {
 	// Best effort: an unknown OS version is better than a failed update check.
 	if version, err := osVersion(); err == nil {
 		req.Header.Set(headerOSVersionKey, version)
+	} else {
+		fmt.Printf("Couldn't detect OS version: %v.\n", err)
 	}
 }

--- a/updater/update/osinfo.go
+++ b/updater/update/osinfo.go
@@ -1,7 +1,7 @@
 // SILVER - Service Wrapper
 // Auto Updater
 //
-// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Copyright (c) 2026 PaperCut Software http://www.papercut.com/
 // Use of this source code is governed by an MIT or GPL Version 2 license.
 // See the project's LICENSE file for more information.
 //

--- a/updater/update/osinfo_test.go
+++ b/updater/update/osinfo_test.go
@@ -1,0 +1,41 @@
+// SILVER - Service Wrapper
+// Auto Updater
+//
+// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Use of this source code is governed by an MIT or GPL Version 2 license.
+// See the project's LICENSE file for more information.
+//
+
+package update
+
+import (
+	"net/http"
+	"regexp"
+	"runtime"
+	"testing"
+)
+
+func TestAddOSContextToRequestHeader(t *testing.T) {
+	req, err := http.NewRequest("GET", "https://example.com/check-update/test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	addOSContextToRequestHeader(req)
+
+	if got := req.Header.Get(headerOSTypeKey); got != runtime.GOOS {
+		t.Errorf("%s = %q, want %q", headerOSTypeKey, got, runtime.GOOS)
+	}
+	if got := req.Header.Get(headerOSArchKey); got != runtime.GOARCH {
+		t.Errorf("%s = %q, want %q", headerOSArchKey, got, runtime.GOARCH)
+	}
+
+	// windows, darwin and linux all report a dot-separated numeric version.
+	switch runtime.GOOS {
+	case "windows", "darwin", "linux":
+		got := req.Header.Get(headerOSVersionKey)
+		if matched := regexp.MustCompile(`^\d+(\.\d+)+`).MatchString(got); !matched {
+			t.Errorf("%s = %q, want a dot-separated numeric version", headerOSVersionKey, got)
+		}
+	}
+}

--- a/updater/update/osinfo_test.go
+++ b/updater/update/osinfo_test.go
@@ -6,13 +6,15 @@
 // See the project's LICENSE file for more information.
 //
 
-package update
+package update_test
 
 import (
 	"net/http"
 	"regexp"
 	"runtime"
 	"testing"
+
+	"github.com/papercutsoftware/silver/updater/update"
 )
 
 func TestTrimToNumericVersion(t *testing.T) {
@@ -33,8 +35,8 @@ func TestTrimToNumericVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := trimToNumericVersion(tt.input); got != tt.want {
-				t.Errorf("trimToNumericVersion(%q) = %q, want %q", tt.input, got, tt.want)
+			if got := update.TrimToNumericVersion(tt.input); got != tt.want {
+				t.Errorf("TrimToNumericVersion(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}
@@ -46,28 +48,28 @@ func TestSetOSHeaders(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	setOSHeaders(req)
+	update.SetOSHeaders(req)
 
-	if got := req.Header.Get(headerOSTypeKey); got != runtime.GOOS {
-		t.Errorf("%s = %q, want %q", headerOSTypeKey, got, runtime.GOOS)
+	if got := req.Header.Get("X-OS-Type"); got != runtime.GOOS {
+		t.Errorf("X-OS-Type = %q, want %q", got, runtime.GOOS)
 	}
-	if got := req.Header.Get(headerOSArchKey); got != runtime.GOARCH {
-		t.Errorf("%s = %q, want %q", headerOSArchKey, got, runtime.GOARCH)
+	if got := req.Header.Get("X-OS-Arch"); got != runtime.GOARCH {
+		t.Errorf("X-OS-Arch = %q, want %q", got, runtime.GOARCH)
 	}
 
 	// Native arch is the binary arch except under emulation, where it must
 	// be arm64 (Rosetta 2 and Windows-on-ARM both emulate on arm64 hosts).
-	nativeGot := req.Header.Get(headerOSNativeArchKey)
+	nativeGot := req.Header.Get("X-OS-Native-Arch")
 	if nativeGot != runtime.GOARCH && nativeGot != "arm64" {
-		t.Errorf("%s = %q, want %q or \"arm64\"", headerOSNativeArchKey, nativeGot, runtime.GOARCH)
+		t.Errorf("X-OS-Native-Arch = %q, want %q or \"arm64\"", nativeGot, runtime.GOARCH)
 	}
 
 	// windows, darwin and linux all report a dot-separated numeric version.
 	switch runtime.GOOS {
 	case "windows", "darwin", "linux":
-		got := req.Header.Get(headerOSVersionKey)
+		got := req.Header.Get("X-OS-Version")
 		if matched := regexp.MustCompile(`^\d+(\.\d+)+`).MatchString(got); !matched {
-			t.Errorf("%s = %q, want a dot-separated numeric version", headerOSVersionKey, got)
+			t.Errorf("X-OS-Version = %q, want a dot-separated numeric version", got)
 		}
 	}
 }

--- a/updater/update/osinfo_test.go
+++ b/updater/update/osinfo_test.go
@@ -17,6 +17,16 @@ import (
 	"github.com/papercutsoftware/silver/updater/update"
 )
 
+func TestUserAgent(t *testing.T) {
+	got := update.UserAgent()
+
+	// "silver-updater" alone (no VCS stamp, e.g. test binaries), or
+	// "silver-updater/<version>" where version is a spaceless token.
+	if matched := regexp.MustCompile(`^silver-updater(/\S+)?$`).MatchString(got); !matched {
+		t.Errorf("userAgent() = %q, want \"silver-updater\" optionally followed by /<version>", got)
+	}
+}
+
 func TestTrimToNumericVersion(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -53,15 +63,15 @@ func TestSetOSHeaders(t *testing.T) {
 	if got := req.Header.Get("X-OS-Type"); got != runtime.GOOS {
 		t.Errorf("X-OS-Type = %q, want %q", got, runtime.GOOS)
 	}
-	if got := req.Header.Get("X-OS-Arch"); got != runtime.GOARCH {
-		t.Errorf("X-OS-Arch = %q, want %q", got, runtime.GOARCH)
+	if got := req.Header.Get("X-Binary-Arch"); got != runtime.GOARCH {
+		t.Errorf("X-Binary-Arch = %q, want %q", got, runtime.GOARCH)
 	}
 
-	// Native arch is the binary arch except under emulation, where it must
+	// OS arch is the binary arch except under emulation, where it must
 	// be arm64 (Rosetta 2 and Windows-on-ARM both emulate on arm64 hosts).
-	nativeGot := req.Header.Get("X-OS-Native-Arch")
-	if nativeGot != runtime.GOARCH && nativeGot != "arm64" {
-		t.Errorf("X-OS-Native-Arch = %q, want %q or \"arm64\"", nativeGot, runtime.GOARCH)
+	osArchGot := req.Header.Get("X-OS-Arch")
+	if osArchGot != runtime.GOARCH && osArchGot != "arm64" {
+		t.Errorf("X-OS-Arch = %q, want %q or \"arm64\"", osArchGot, runtime.GOARCH)
 	}
 
 	// windows, darwin and linux all report a dot-separated numeric version.

--- a/updater/update/osinfo_test.go
+++ b/updater/update/osinfo_test.go
@@ -30,6 +30,13 @@ func TestAddOSContextToRequestHeader(t *testing.T) {
 		t.Errorf("%s = %q, want %q", headerOSArchKey, got, runtime.GOARCH)
 	}
 
+	// Native arch is the binary arch except under emulation, where it must
+	// be arm64 (Rosetta 2 and Windows-on-ARM both emulate on arm64 hosts).
+	nativeGot := req.Header.Get(headerOSNativeArchKey)
+	if nativeGot != runtime.GOARCH && nativeGot != "arm64" {
+		t.Errorf("%s = %q, want %q or \"arm64\"", headerOSNativeArchKey, nativeGot, runtime.GOARCH)
+	}
+
 	// windows, darwin and linux all report a dot-separated numeric version.
 	switch runtime.GOOS {
 	case "windows", "darwin", "linux":

--- a/updater/update/osinfo_test.go
+++ b/updater/update/osinfo_test.go
@@ -40,13 +40,13 @@ func TestTrimToNumericVersion(t *testing.T) {
 	}
 }
 
-func TestAddOSContextToRequestHeader(t *testing.T) {
+func TestSetOSHeaders(t *testing.T) {
 	req, err := http.NewRequest("GET", "https://example.com/check-update/test", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	addOSContextToRequestHeader(req)
+	setOSHeaders(req)
 
 	if got := req.Header.Get(headerOSTypeKey); got != runtime.GOOS {
 		t.Errorf("%s = %q, want %q", headerOSTypeKey, got, runtime.GOOS)

--- a/updater/update/osinfo_test.go
+++ b/updater/update/osinfo_test.go
@@ -1,7 +1,7 @@
 // SILVER - Service Wrapper
 // Auto Updater
 //
-// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Copyright (c) 2026 PaperCut Software http://www.papercut.com/
 // Use of this source code is governed by an MIT or GPL Version 2 license.
 // See the project's LICENSE file for more information.
 //

--- a/updater/update/osinfo_test.go
+++ b/updater/update/osinfo_test.go
@@ -15,6 +15,31 @@ import (
 	"testing"
 )
 
+func TestTrimToNumericVersion(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"vanilla kernel", "6.17.24", "6.17.24"},
+		{"ubuntu", "5.15.0-91-generic", "5.15.0"},
+		{"debian", "6.1.0-13-amd64", "6.1.0"},
+		{"rhel", "4.18.0-477.10.1.el8_8.x86_64", "4.18.0"},
+		{"amazon linux", "6.1.66-91.160.amzn2023.x86_64", "6.1.66"},
+		{"no trailing dot kept", "5.15.", "5.15"},
+		{"non-numeric prefix", "generic-5.15", ""},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := trimToNumericVersion(tt.input); got != tt.want {
+				t.Errorf("trimToNumericVersion(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAddOSContextToRequestHeader(t *testing.T) {
 	req, err := http.NewRequest("GET", "https://example.com/check-update/test", nil)
 	if err != nil {

--- a/updater/update/osnativearch_darwin.go
+++ b/updater/update/osnativearch_darwin.go
@@ -6,8 +6,6 @@
 // See the project's LICENSE file for more information.
 //
 
-//go:build darwin
-
 package update
 
 import (

--- a/updater/update/osnativearch_darwin.go
+++ b/updater/update/osnativearch_darwin.go
@@ -1,0 +1,27 @@
+// SILVER - Service Wrapper
+// Auto Updater
+//
+// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Use of this source code is governed by an MIT or GPL Version 2 license.
+// See the project's LICENSE file for more information.
+//
+
+//go:build darwin
+
+package update
+
+import (
+	"runtime"
+	"syscall"
+)
+
+// nativeArch returns the host CPU architecture, which differs from
+// runtime.GOARCH when an x64 binary runs under Rosetta 2 translation.
+// sysctl.proc_translated is 1 for translated processes; the sysctl does
+// not exist on Intel Macs (Sysctl returns an error).
+func nativeArch() string {
+	if translated, err := syscall.SysctlUint32("sysctl.proc_translated"); err == nil && translated == 1 {
+		return "arm64"
+	}
+	return runtime.GOARCH
+}

--- a/updater/update/osnativearch_darwin.go
+++ b/updater/update/osnativearch_darwin.go
@@ -1,7 +1,7 @@
 // SILVER - Service Wrapper
 // Auto Updater
 //
-// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Copyright (c) 2026 PaperCut Software http://www.papercut.com/
 // Use of this source code is governed by an MIT or GPL Version 2 license.
 // See the project's LICENSE file for more information.
 //

--- a/updater/update/osnativearch_other.go
+++ b/updater/update/osnativearch_other.go
@@ -1,0 +1,20 @@
+// SILVER - Service Wrapper
+// Auto Updater
+//
+// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Use of this source code is governed by an MIT or GPL Version 2 license.
+// See the project's LICENSE file for more information.
+//
+
+//go:build !windows && !darwin
+
+package update
+
+import "runtime"
+
+// nativeArch assumes the host architecture matches the binary on platforms
+// without a reliable emulation signal (user-mode emulation on Linux is rare
+// and deliberately hides itself from uname).
+func nativeArch() string {
+	return runtime.GOARCH
+}

--- a/updater/update/osnativearch_other.go
+++ b/updater/update/osnativearch_other.go
@@ -1,7 +1,7 @@
 // SILVER - Service Wrapper
 // Auto Updater
 //
-// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Copyright (c) 2026 PaperCut Software http://www.papercut.com/
 // Use of this source code is governed by an MIT or GPL Version 2 license.
 // See the project's LICENSE file for more information.
 //

--- a/updater/update/osnativearch_windows.go
+++ b/updater/update/osnativearch_windows.go
@@ -1,0 +1,40 @@
+// SILVER - Service Wrapper
+// Auto Updater
+//
+// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Use of this source code is governed by an MIT or GPL Version 2 license.
+// See the project's LICENSE file for more information.
+//
+
+//go:build windows
+
+package update
+
+import (
+	"runtime"
+
+	"golang.org/x/sys/windows"
+)
+
+// nativeArch returns the host CPU architecture, which differs from
+// runtime.GOARCH when the binary runs under emulation (e.g. x64 on
+// Windows-on-ARM). IsWow64Process2 reports the native machine regardless
+// of emulation; it is unavailable before Windows 10 1511, but no such
+// host is an ARM64 machine, so falling back to GOARCH is correct there.
+func nativeArch() string {
+	var processMachine, nativeMachine uint16
+	if err := windows.IsWow64Process2(windows.CurrentProcess(), &processMachine, &nativeMachine); err != nil {
+		return runtime.GOARCH
+	}
+	switch nativeMachine {
+	case 0xAA64: // IMAGE_FILE_MACHINE_ARM64
+		return "arm64"
+	case 0x8664: // IMAGE_FILE_MACHINE_AMD64
+		return "amd64"
+	case 0x014C: // IMAGE_FILE_MACHINE_I386
+		return "386"
+	case 0x01C4: // IMAGE_FILE_MACHINE_ARMNT
+		return "arm"
+	}
+	return runtime.GOARCH
+}

--- a/updater/update/osnativearch_windows.go
+++ b/updater/update/osnativearch_windows.go
@@ -6,8 +6,6 @@
 // See the project's LICENSE file for more information.
 //
 
-//go:build windows
-
 package update
 
 import (

--- a/updater/update/osnativearch_windows.go
+++ b/updater/update/osnativearch_windows.go
@@ -1,7 +1,7 @@
 // SILVER - Service Wrapper
 // Auto Updater
 //
-// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Copyright (c) 2026 PaperCut Software http://www.papercut.com/
 // Use of this source code is governed by an MIT or GPL Version 2 license.
 // See the project's LICENSE file for more information.
 //

--- a/updater/update/osversion_darwin.go
+++ b/updater/update/osversion_darwin.go
@@ -1,0 +1,18 @@
+// SILVER - Service Wrapper
+// Auto Updater
+//
+// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Use of this source code is governed by an MIT or GPL Version 2 license.
+// See the project's LICENSE file for more information.
+//
+
+//go:build darwin
+
+package update
+
+import "syscall"
+
+// osVersion returns the macOS product version (e.g. "14.5").
+func osVersion() (string, error) {
+	return syscall.Sysctl("kern.osproductversion")
+}

--- a/updater/update/osversion_darwin.go
+++ b/updater/update/osversion_darwin.go
@@ -6,8 +6,6 @@
 // See the project's LICENSE file for more information.
 //
 
-//go:build darwin
-
 package update
 
 import "syscall"

--- a/updater/update/osversion_darwin.go
+++ b/updater/update/osversion_darwin.go
@@ -8,9 +8,19 @@
 
 package update
 
-import "syscall"
+import (
+	"errors"
+	"syscall"
+)
 
 // osVersion returns the macOS product version (e.g. "14.5").
 func osVersion() (string, error) {
-	return syscall.Sysctl("kern.osproductversion")
+	version, err := syscall.Sysctl("kern.osproductversion")
+	if err != nil {
+		return "", err
+	}
+	if version == "" {
+		return "", errors.New("kern.osproductversion is empty")
+	}
+	return version, nil
 }

--- a/updater/update/osversion_darwin.go
+++ b/updater/update/osversion_darwin.go
@@ -1,7 +1,7 @@
 // SILVER - Service Wrapper
 // Auto Updater
 //
-// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Copyright (c) 2026 PaperCut Software http://www.papercut.com/
 // Use of this source code is governed by an MIT or GPL Version 2 license.
 // See the project's LICENSE file for more information.
 //

--- a/updater/update/osversion_linux.go
+++ b/updater/update/osversion_linux.go
@@ -10,11 +10,12 @@ package update
 
 import "golang.org/x/sys/unix"
 
-// osVersion returns the Linux kernel release (e.g. "6.17.24") via uname.
+// osVersion returns the Linux kernel version (e.g. "5.15.0") via uname,
+// trimming distro suffixes from the release string ("5.15.0-91-generic").
 func osVersion() (string, error) {
 	var uts unix.Utsname
 	if err := unix.Uname(&uts); err != nil {
 		return "", err
 	}
-	return unix.ByteSliceToString(uts.Release[:]), nil
+	return trimToNumericVersion(unix.ByteSliceToString(uts.Release[:])), nil
 }

--- a/updater/update/osversion_linux.go
+++ b/updater/update/osversion_linux.go
@@ -1,0 +1,22 @@
+// SILVER - Service Wrapper
+// Auto Updater
+//
+// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Use of this source code is governed by an MIT or GPL Version 2 license.
+// See the project's LICENSE file for more information.
+//
+
+//go:build linux
+
+package update
+
+import "golang.org/x/sys/unix"
+
+// osVersion returns the Linux kernel release (e.g. "6.17.24") via uname.
+func osVersion() (string, error) {
+	var uts unix.Utsname
+	if err := unix.Uname(&uts); err != nil {
+		return "", err
+	}
+	return unix.ByteSliceToString(uts.Release[:]), nil
+}

--- a/updater/update/osversion_linux.go
+++ b/updater/update/osversion_linux.go
@@ -6,8 +6,6 @@
 // See the project's LICENSE file for more information.
 //
 
-//go:build linux
-
 package update
 
 import "golang.org/x/sys/unix"

--- a/updater/update/osversion_linux.go
+++ b/updater/update/osversion_linux.go
@@ -8,7 +8,11 @@
 
 package update
 
-import "golang.org/x/sys/unix"
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
 
 // osVersion returns the Linux kernel version (e.g. "5.15.0") via uname,
 // trimming distro suffixes from the release string ("5.15.0-91-generic").
@@ -17,5 +21,10 @@ func osVersion() (string, error) {
 	if err := unix.Uname(&uts); err != nil {
 		return "", err
 	}
-	return trimToNumericVersion(unix.ByteSliceToString(uts.Release[:])), nil
+	release := unix.ByteSliceToString(uts.Release[:])
+	version := trimToNumericVersion(release)
+	if version == "" {
+		return "", fmt.Errorf("unrecognized kernel release %q", release)
+	}
+	return version, nil
 }

--- a/updater/update/osversion_linux.go
+++ b/updater/update/osversion_linux.go
@@ -1,7 +1,7 @@
 // SILVER - Service Wrapper
 // Auto Updater
 //
-// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Copyright (c) 2026 PaperCut Software http://www.papercut.com/
 // Use of this source code is governed by an MIT or GPL Version 2 license.
 // See the project's LICENSE file for more information.
 //

--- a/updater/update/osversion_other.go
+++ b/updater/update/osversion_other.go
@@ -10,8 +10,13 @@
 
 package update
 
-// osVersion is unknown on unsupported platforms; the X-OS-Version header is
-// simply omitted.
+import (
+	"fmt"
+	"runtime"
+)
+
+// osVersion has no detection on this platform; the caller omits the
+// X-OS-Version header on error.
 func osVersion() (string, error) {
-	return "", nil
+	return "", fmt.Errorf("no OS version detection support for %s", runtime.GOOS)
 }

--- a/updater/update/osversion_other.go
+++ b/updater/update/osversion_other.go
@@ -1,0 +1,17 @@
+// SILVER - Service Wrapper
+// Auto Updater
+//
+// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Use of this source code is governed by an MIT or GPL Version 2 license.
+// See the project's LICENSE file for more information.
+//
+
+//go:build !windows && !darwin && !linux
+
+package update
+
+// osVersion is unknown on unsupported platforms; the X-OS-Version header is
+// simply omitted.
+func osVersion() (string, error) {
+	return "", nil
+}

--- a/updater/update/osversion_other.go
+++ b/updater/update/osversion_other.go
@@ -1,7 +1,7 @@
 // SILVER - Service Wrapper
 // Auto Updater
 //
-// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Copyright (c) 2026 PaperCut Software http://www.papercut.com/
 // Use of this source code is governed by an MIT or GPL Version 2 license.
 // See the project's LICENSE file for more information.
 //

--- a/updater/update/osversion_windows.go
+++ b/updater/update/osversion_windows.go
@@ -1,0 +1,25 @@
+// SILVER - Service Wrapper
+// Auto Updater
+//
+// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Use of this source code is governed by an MIT or GPL Version 2 license.
+// See the project's LICENSE file for more information.
+//
+
+//go:build windows
+
+package update
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+// osVersion returns the Windows version as major.minor.build (e.g.
+// "10.0.19041"). RtlGetVersion reports the true OS version, unaffected by
+// the compatibility shims that skew GetVersionEx.
+func osVersion() (string, error) {
+	info := windows.RtlGetVersion()
+	return fmt.Sprintf("%d.%d.%d", info.MajorVersion, info.MinorVersion, info.BuildNumber), nil
+}

--- a/updater/update/osversion_windows.go
+++ b/updater/update/osversion_windows.go
@@ -1,12 +1,10 @@
 // SILVER - Service Wrapper
 // Auto Updater
 //
-// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Copyright (c) 2026 PaperCut Software http://www.papercut.com/
 // Use of this source code is governed by an MIT or GPL Version 2 license.
 // See the project's LICENSE file for more information.
 //
-
-//go:build windows
 
 package update
 

--- a/updater/update/update.go
+++ b/updater/update/update.go
@@ -41,7 +41,7 @@ func Check(updateURL string, currentVer string, publicKey string) (*UpgradeInfo,
 	}
 	req.Header.Set("User-Agent", "Update Check")
 	addIDProfileToRequestHeader(req)
-	addOSContextToRequestHeader(req)
+	setOSHeaders(req)
 
 	res, err := client.Do(req)
 	if err != nil {

--- a/updater/update/update.go
+++ b/updater/update/update.go
@@ -39,7 +39,7 @@ func Check(updateURL string, currentVer string, publicKey string) (*UpgradeInfo,
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", "Update Check")
+	req.Header.Set("User-Agent", userAgent())
 	addIDProfileToRequestHeader(req)
 	setOSHeaders(req)
 

--- a/updater/update/update.go
+++ b/updater/update/update.go
@@ -41,6 +41,7 @@ func Check(updateURL string, currentVer string, publicKey string) (*UpgradeInfo,
 	}
 	req.Header.Set("User-Agent", "Update Check")
 	addIDProfileToRequestHeader(req)
+	addOSContextToRequestHeader(req)
 
 	res, err := client.Do(req)
 	if err != nil {

--- a/updater/update/update.go
+++ b/updater/update/update.go
@@ -1,7 +1,7 @@
 // SILVER - Service Wrapper
 // Auto Updater
 //
-// Copyright (c) 2014-2021 PaperCut Software http://www.papercut.com/
+// Copyright (c) 2014-2026 PaperCut Software http://www.papercut.com/
 // Use of this source code is governed by an MIT or GPL Version 2 license.
 // See the project's LICENSE file for more information.
 //

--- a/updater/update/useragent.go
+++ b/updater/update/useragent.go
@@ -1,0 +1,24 @@
+// SILVER - Service Wrapper
+// Auto Updater
+//
+// Copyright (c) 2026 PaperCut Software http://www.papercut.com/
+// Use of this source code is governed by an MIT or GPL Version 2 license.
+// See the project's LICENSE file for more information.
+//
+
+package update
+
+import "runtime/debug"
+
+// userAgent returns the User-Agent for update check requests, e.g.
+// "silver-updater/v1.6.1". The version is stamped automatically by the Go
+// toolchain from the module's VCS tag; builds without VCS information
+// (or from an untagged tree reporting "(devel)") omit it.
+func userAgent() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if v := info.Main.Version; v != "" && v != "(devel)" {
+			return "silver-updater/" + v
+		}
+	}
+	return "silver-updater"
+}


### PR DESCRIPTION
The updater now sends X-OS-Type, X-OS-Version and X-OS-Arch with every update check, giving the update server the context to select a build compatible with this host.

X-OS-Type and X-OS-Arch carry runtime.GOOS and runtime.GOARCH verbatim, so no OS/arch mapping code ships in the client; the server owns the vocabulary.

X-OS-Version is best effort and omitted if detection fails:
- Windows: RtlGetVersion (major.minor.build, unaffected by compatibility shims)
- macOS: sysctl kern.osproductversion
- Linux: kernel release via uname