### PR TITLE
feat(service): add -v version flag to print version and OS/arch info

### DIFF
--- a/make.go
+++ b/make.go
@@ -92,7 +92,7 @@ func main() {
 // local development builds.
 func resolveVersion(flagVersion string) string {
 	if flagVersion != "" {
-		return strings.TrimPrefix(flagVersion, "v") // Strip leading "v" so callers can pass git tag (e.g. v1.8.0) directly.
+		return flagVersion
 	}
 	return "dev"
 }

--- a/make.go
+++ b/make.go
@@ -57,6 +57,7 @@ func usage() {
 func main() {
 	goos := flag.String("goos", runtime.GOOS, "Specify target operating system for cross compilation")
 	goarch := flag.String("goarch", runtime.GOARCH, "Specify target architecture for cross compilation")
+	versionFlag := flag.String("version", "", "Specify version string to inject into binaries")
 	flag.Parse()
 
 	_ = os.Setenv("GOOS", *goos)
@@ -74,9 +75,11 @@ func main() {
 		action = flag.Arg(0)
 	}
 
+	ver := resolveVersion(*versionFlag)
+
 	switch action {
 	case "all":
-		buildAll()
+		buildAll(ver)
 	case "test":
 		testAll()
 	default:
@@ -84,19 +87,37 @@ func main() {
 	}
 }
 
-func buildAll() {
+// resolveVersion resolves the build version string using the following priority order:
+// 1. Explicit CLI flag (e.g. go run make.go -version 1.8.0).
+// 2. CI environment variables (SILVER_VERSION or SILVER_RELEASE_TAG).
+// 3. Fallback "dev" for unflagged local development builds.
+func resolveVersion(flagVersion string) string {
+	if flagVersion != "" {
+		return strings.TrimPrefix(flagVersion, "v")
+	}
+	if v := os.Getenv("SILVER_VERSION"); v != "" {
+		return strings.TrimPrefix(v, "v")
+	}
+	if tag := os.Getenv("SILVER_RELEASE_TAG"); tag != "" {
+		return strings.TrimPrefix(tag, "v")
+	}
+	return "dev"
+}
+
+func buildAll(ver string) {
 	makeDir(buildOutputDir)
 
 	goos := os.Getenv("GOOS")
 	goarch := os.Getenv("GOARCH")
+	ldflags := fmt.Sprintf("-s -w -X main.Version=%s", ver)
 
-	fmt.Printf("Building binaries for %s/%s ...\n", goos, goarch)
+	fmt.Printf("Building binaries for %s/%s (version %s) ...\n", goos, goarch, ver)
 	_ = runCmd("go", "build", "-ldflags", "-s -w", "-o", makeOutputPath(buildOutputDir, "updater"), rootNamespace+"/updater")
-	_ = runCmd("go", "build", "-ldflags", "-s -w", "-o", makeOutputPath(buildOutputDir, "service"), rootNamespace+"/service")
+	_ = runCmd("go", "build", "-ldflags", ldflags, "-o", makeOutputPath(buildOutputDir, "service"), rootNamespace+"/service")
 	_ = runCmd("go", "build", "-ldflags", "", "-o", makeOutputPath(buildOutputDir, "jsonsig"), rootNamespace+"/lib/jsonsig/cmd")
-	_ = runCmd("go", "build", "-tags", "nohttp", "-ldflags", "-s -w", "-o", makeOutputPath(buildOutputDir, "service-no-http"), rootNamespace+"/service")
+	_ = runCmd("go", "build", "-tags", "nohttp", "-ldflags", ldflags, "-o", makeOutputPath(buildOutputDir, "service-no-http"), rootNamespace+"/service")
 	if goos == "windows" {
-		_ = runCmd("go", "build", "-tags", "nohttp", "-ldflags", "-s -w  -H=windowsgui", "-o", makeOutputPath(buildOutputDir, "service-no-window"), rootNamespace+"/service")
+		_ = runCmd("go", "build", "-tags", "nohttp", "-ldflags", ldflags+" -H=windowsgui", "-o", makeOutputPath(buildOutputDir, "service-no-window"), rootNamespace+"/service")
 		_ = runCmd("go", "build", "-ldflags", "-s -w -H=windowsgui", "-o", makeOutputPath(buildOutputDir, "updater-no-window"), rootNamespace+"/updater")
 	}
 

--- a/make.go
+++ b/make.go
@@ -87,19 +87,12 @@ func main() {
 	}
 }
 
-// resolveVersion resolves the build version string using the following priority order:
-// 1. Explicit CLI flag (e.g. go run make.go -version 1.8.0).
-// 2. CI environment variables (SILVER_VERSION or SILVER_RELEASE_TAG).
-// 3. Fallback "dev" for unflagged local development builds.
+// resolveVersion resolves the build version string from the explicit CLI flag
+// (e.g. go run make.go -version 1.8.0), falling back to "dev" for unflagged
+// local development builds.
 func resolveVersion(flagVersion string) string {
 	if flagVersion != "" {
-		return strings.TrimPrefix(flagVersion, "v")
-	}
-	if v := os.Getenv("SILVER_VERSION"); v != "" {
-		return strings.TrimPrefix(v, "v")
-	}
-	if tag := os.Getenv("SILVER_RELEASE_TAG"); tag != "" {
-		return strings.TrimPrefix(tag, "v")
+		return strings.TrimPrefix(flagVersion, "v") // Strip leading "v" so callers can pass git tag (e.g. v1.8.0) directly.
 	}
 	return "dev"
 }

--- a/service/args.go
+++ b/service/args.go
@@ -52,7 +52,6 @@ var aliases = map[string]string{
 	"delete": "uninstall",
 	"check":  "validate",
 	"test":   "validate",
-	"v":      "version",
 }
 
 func normalizeArgs(args []string) []string {

--- a/service/args.go
+++ b/service/args.go
@@ -29,6 +29,7 @@ var validArgs = []string{
 	"validate",
 	"run",
 	"command",
+	"version",
 }
 
 func isArgsValid(args []string) bool {
@@ -51,6 +52,7 @@ var aliases = map[string]string{
 	"delete": "uninstall",
 	"check":  "validate",
 	"test":   "validate",
+	"v":      "version",
 }
 
 func normalizeArgs(args []string) []string {

--- a/service/main.go
+++ b/service/main.go
@@ -52,13 +52,13 @@ func printVersion() {
 
 func run() (exitCode int) {
 	// Parse CLI args early to support diagnostic version command without requiring a config file.
-	action, actionArgs, err := parse(os.Args)
-	if err == nil && action == "version" {
+	action, actionArgs, parseErr := parse(os.Args)
+	if parseErr == nil && action == "version" {
 		printVersion()
 		return 0
 	}
 
-	err = os.Chdir(exeFolder())
+	err := os.Chdir(exeFolder())
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "ERROR: Unable to set working directory: %v\n", err)
 		return 1
@@ -72,7 +72,7 @@ func run() (exitCode int) {
 		_, _ = fmt.Fprintf(os.Stderr, "ERROR: Invalid config - %v\n", err)
 		return 1
 	}
-	if err != nil {
+	if parseErr != nil {
 		printUsage(ctx.conf.ServiceDescription.DisplayName, ctx.conf.ServiceDescription.Description)
 		return 1
 	}

--- a/service/main.go
+++ b/service/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -42,8 +43,22 @@ func main() {
 	os.Exit(run())
 }
 
+// Version represents the build version string, set at build time via -ldflags "-X main.Version=x.y.z".
+var Version = "dev"
+
+func printVersion() {
+	fmt.Printf("silver version %s %s/%s\n", Version, runtime.GOOS, runtime.GOARCH)
+}
+
 func run() (exitCode int) {
-	err := os.Chdir(exeFolder())
+	// Parse CLI args early to support diagnostic version flag (-v) without requiring a config file.
+	action, actionArgs, err := parse(os.Args)
+	if err == nil && action == "version" {
+		printVersion()
+		return 0
+	}
+
+	err = os.Chdir(exeFolder())
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "ERROR: Unable to set working directory: %v\n", err)
 		return 1
@@ -57,8 +72,6 @@ func run() (exitCode int) {
 		_, _ = fmt.Fprintf(os.Stderr, "ERROR: Invalid config - %v\n", err)
 		return 1
 	}
-
-	action, actionArgs, err := parse(os.Args)
 	if err != nil {
 		printUsage(ctx.conf.ServiceDescription.DisplayName, ctx.conf.ServiceDescription.Description)
 		return 1
@@ -155,7 +168,7 @@ func printUsage(svcDisplayName, svcDesc string) {
 		serviceName())
 	fmt.Printf("%s\n\n", svcDesc)
 	fmt.Printf("Usage:\n")
-	fmt.Printf("%s [install|uninstall|start|stop|command|validate|run|help] [command-name]\n", exeName())
+	fmt.Printf("%s [install|uninstall|start|stop|command|validate|run|version|help] [command-name]\n", exeName())
 	fmt.Printf("  install   - Install the service.\n")
 	fmt.Printf("  uninstall - Remove/uninstall the service.\n")
 	fmt.Printf("  start     - Start an installed service.\n")
@@ -163,6 +176,7 @@ func printUsage(svcDisplayName, svcDesc string) {
 	fmt.Printf("  validate  - Test the configuration file.\n")
 	fmt.Printf("  run       - Run service on in command-line mode.\n")
 	fmt.Printf("  command   - Run a command [command-name].\n")
+	fmt.Printf("  version   - Display version and target OS/architecture (-v).\n")
 	fmt.Printf("  help      - This usage message.\n")
 }
 

--- a/service/main.go
+++ b/service/main.go
@@ -51,7 +51,7 @@ func printVersion() {
 }
 
 func run() (exitCode int) {
-	// Parse CLI args early to support diagnostic version flag (-v) without requiring a config file.
+	// Parse CLI args early to support diagnostic version command without requiring a config file.
 	action, actionArgs, err := parse(os.Args)
 	if err == nil && action == "version" {
 		printVersion()
@@ -176,7 +176,7 @@ func printUsage(svcDisplayName, svcDesc string) {
 	fmt.Printf("  validate  - Test the configuration file.\n")
 	fmt.Printf("  run       - Run service on in command-line mode.\n")
 	fmt.Printf("  command   - Run a command [command-name].\n")
-	fmt.Printf("  version   - Display version and target OS/architecture (-v).\n")
+	fmt.Printf("  version   - Display version and target OS/architecture.\n")
 	fmt.Printf("  help      - This usage message.\n")
 }
 


### PR DESCRIPTION
Adds a -v (version) CLI flag to the Silver service binary to display version and OS/architecture details in standard Go format.
```
silver version <ver> <os>/<arch>
```
The version flag executes early before config loading, enabling quick host compatibility checks.

Examples.
* macOS (Intel / Rosetta): `silver version 1.0.0 darwin/amd64`                                                          
* Linux: `silver version 1.7.0 linux/amd64`                                                                                                                  
* Windows: `silver version 1.7.0 windows/amd64`                                                                                                             
* Unversioned Dev Build: `silver version dev darwin/arm64`